### PR TITLE
2.0.0 withSession to adapt to both pages and API Routes

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,7 +3,7 @@ const { promisify } = require('util');
 const request = require('supertest');
 const cookie = require('cookie');
 const session = require('../src/index');
-const { useSession } = require('../src/index');
+const { useSession, withSession } = require('../src/index');
 const MemoryStore = require('../src/session/memory');
 
 const modifyReq = (handler, reqq) => (req, res) => {
@@ -20,7 +20,7 @@ const modifyReq = (handler, reqq) => (req, res) => {
 describe('session', () => {
   const server = http.createServer(
     modifyReq(
-      session((req, res) => {
+      withSession((req, res) => {
         if (req.method === 'POST') {
           req.session.johncena = 'invisible';
           return res.end();
@@ -53,7 +53,7 @@ describe('session', () => {
     const req = { cookies: {} };
     const res = { end: () => null };
     const handler = (req) => req.sessionStore;
-    return session(handler)(req, res).then((result) => {
+    return withSession(handler)(req, res).then((result) => {
       expect(result).toBeInstanceOf(MemoryStore);
     });
   });
@@ -61,7 +61,7 @@ describe('session', () => {
   test.each([10, 'string', true, {}])(
     'should throw if generateId is not a function',
     (generateId) => {
-      expect(() => { session(null, { generateId }); }).toThrow();
+      expect(() => { withSession(null, { generateId }); }).toThrow();
     },
   );
   test('should do nothing if req.session is defined', () => request(server).get('/definedSessionTest')
@@ -98,9 +98,6 @@ describe('useSession (getInitialProps)', () => {
   });
   test('useSession should return if no req', async () => {
     expect(useSession()).toStrictEqual(undefined);
-  });
-  test('useSession should throw TypeError if no res argument', async () => {
-    expect(() => { useSession(() => {}); }).toThrow();
   });
   test('useSession to parse cookies', async () => {
     const req = {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -89,17 +89,16 @@ describe('session (using withSession)', () => {
   });
 });
 
-describe('useSession', () => {
-  test('useSession to register req.session', async () => {
-    const req = {
-      headers: {
-        cookie: '',
-      },
-    };
-    const res = {};
-    await useSession(req, res);
-    expect(req.session).toBeInstanceOf(session.Session);
+describe('withSession', () => {
+  test('withSession should return if no req', async () => {
+    const req = undefined;
+    const res = undefined;
+    const handler = (req) => req && req.session;
+    expect(await withSession(handler)(req, res)).toStrictEqual(undefined);
   });
+});
+
+describe('useSession', () => {
   test('useSession should return if no req', async () => {
     const req = undefined;
     const res = undefined;
@@ -114,5 +113,15 @@ describe('useSession', () => {
     const res = {};
     await useSession(req, res);
     expect(req.cookies.sessionId).toStrictEqual('YmFieXlvdWFyZWJlYXV0aWZ1bA');
+  });
+  test('useSession to register req.session', async () => {
+    const req = {
+      headers: {
+        cookie: '',
+      },
+    };
+    const res = {};
+    await useSession(req, res);
+    expect(req.session).toBeInstanceOf(session.Session);
   });
 });

--- a/test/memory.test.js
+++ b/test/memory.test.js
@@ -3,7 +3,7 @@ const { promisify } = require('util');
 const request = require('supertest');
 const cookie = require('cookie');
 const url = require('url');
-const session = require('../src/index');
+const { withSession } = require('../src/index');
 
 const modifyReq = (handler, reqq) => (req, res) => {
   req.query = url.parse(req.url, true).query;
@@ -16,7 +16,7 @@ const modifyReq = (handler, reqq) => (req, res) => {
 describe('session', () => {
   const server = http.createServer(
     modifyReq(
-      session((req, res) => {
+      withSession((req, res) => {
         if (req.url === '/all') {
           req.sessionStore.all().then((sessions) => {
             const users = sessions.map((sess) => JSON.parse(sess).user);


### PR DESCRIPTION
This PR will introduce a rewrite on current APIs:
- [x] useSession works for API Routes
- [x] useSession works for _app, _document, pages
- [x] withSession works for API Routes
- [ ] withSession works for _app, _document, pages