### PR TITLE
Rewrite doc and add deprecated warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,6 +171,12 @@ const withSession = (handler, options) => {
   return handler;
 };
 
+module.exports = (handler, options) => {
+  //  Deprecated usage
+  // eslint-disable-next-line no-console
+  console.warn('The use of default import session() is deprecated. Please see https://github.com/hoangvvo/next-session/releases/tag/v2.0.0');
+  return withSession(handler, options);
+};
 module.exports.withSession = withSession;
 module.exports.useSession = useSession;
 module.exports.Store = Store;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,6 +41,13 @@ describe('session (basic)', () => {
     await useSession(req, res);
     expect(req.cookies.sessionId).toStrictEqual('YmFieXlvdWFyZWJlYXV0aWZ1bA');
   });
+
+  test('Deprecated session() should fallback to withSession', async () => {
+    const req = { cookies: {} };
+    const res = {};
+    const handler = (req) => req.session;
+    expect(await session(handler)(req, res)).toBeInstanceOf(session.Session);
+  });
 });
 
 describe('session (using withSession API Routes)', () => {


### PR DESCRIPTION
This will close #21.

It also adds a deprecated warning if one tries to use the default import. `import session from 'next-session'`