### PR TITLE
FIX: TypeError with connect-pg-simple Session Store

### DIFF
--- a/src/session/store.js
+++ b/src/session/store.js
@@ -1,29 +1,28 @@
-/* eslint-disable class-methods-use-this */
+const util = require('util');
 const EventEmitter = require('events');
 const Session = require('./session');
 const Cookie = require('./cookie');
 
-class Store extends EventEmitter {
-  constructor() {
-    super();
-    EventEmitter.call(this);
-  }
-
-  generate(req, genId, cookieOptions) {
-    req.sessionId = genId;
-    req.session = new Session(req);
-    req.session.cookie = new Cookie(cookieOptions);
-    return req.session;
-  }
-
-  createSession(req, sess) {
-    const thisSess = sess;
-    const { expires } = thisSess.cookie;
-    thisSess.cookie = new Cookie(thisSess.cookie);
-    if (typeof expires === 'string') thisSess.cookie.expires = new Date(expires);
-    req.session = new Session(req, thisSess);
-    return req.session;
-  }
+function Store() {
+  EventEmitter.call(this);
 }
+
+util.inherits(Store, EventEmitter);
+
+Store.prototype.generate = function generate(req, genId, cookieOptions) {
+  req.sessionId = genId;
+  req.session = new Session(req);
+  req.session.cookie = new Cookie(cookieOptions);
+  return req.session;
+};
+
+Store.prototype.createSession = function createSession(req, sess) {
+  const thisSess = sess;
+  const { expires } = thisSess.cookie;
+  thisSess.cookie = new Cookie(thisSess.cookie);
+  if (typeof expires === 'string') thisSess.cookie.expires = new Date(expires);
+  req.session = new Session(req, thisSess);
+  return req.session;
+};
 
 module.exports = Store;

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -16,4 +16,15 @@ describe('Store', () => {
     store.createSession(req, sess);
     expect(req.session.cookie.expires).toBeInstanceOf(Date);
   });
+
+  test('should allow store subclasses to use Store.call(this)', () => {
+    // Some express-compatible stores use this pattern like
+    // https://github.com/voxpelli/node-connect-pg-simple/blob/master/index.js
+    function SubStore(options) {
+      options = options || {};
+      Store.call(this, options);
+    }
+
+    const store = new SubStore();
+  });
 });


### PR DESCRIPTION
Closes https://github.com/hoangvvo/next-session/issues/28

Allow express-compatible stores that use Store.call(this, options). Instead of using es6 classes, this uses util.inherits() like express-session.