### PR TITLE
Add support connect style middleware

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -181,12 +181,9 @@ const withSession = (handler, options) => {
   return handler;
 };
 
-module.exports = (handler, options) => {
-  //  Deprecated usage
-  // eslint-disable-next-line no-console
-  console.warn('The use of default import session() is deprecated. Please see https://github.com/hoangvvo/next-session/releases/tag/v2.0.0');
-  return withSession(handler, options);
-};
+const session = (opts) => (req, res, next) => applySession(opts)(req, res).then(next());
+
+module.exports = session;
 module.exports.withSession = withSession;
 module.exports.useSession = useSession;
 module.exports.Store = Store;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -41,13 +41,6 @@ describe('session (basic)', () => {
     await useSession(req, res);
     expect(req.cookies.sessionId).toStrictEqual('YmFieXlvdWFyZWJlYXV0aWZ1bA');
   });
-
-  test('Deprecated session() should fallback to withSession', async () => {
-    const req = { cookies: {} };
-    const res = {};
-    const handler = (req) => req.session;
-    expect(await session(handler)(req, res)).toBeInstanceOf(session.Session);
-  });
 });
 
 describe('session (using withSession API Routes)', () => {
@@ -66,7 +59,7 @@ describe('session (using withSession API Routes)', () => {
       withSession((req, res) => {
         if (req.method === 'POST') {
           req.session.johncena = 'invisible';
-          if (req.headers["res-end-twice"]) {
+          if (req.headers['res-end-twice']) {
             res.end();
           }
           return res.end();
@@ -92,7 +85,7 @@ describe('session (using withSession API Routes)', () => {
 
   test('should create session properly and persist sessionId', () => {
     const agent = request.agent(server);
-    return agent.post('/', { headers: { "res-end-twice": "true" } })
+    return agent.post('/', { headers: { 'res-end-twice': 'true' } })
       .then(() => agent.get('/').expect('invisible'))
       .then(({ header }) => expect(header).not.toHaveProperty('set-cookie'));
     //  should not set cookie since session with data is established


### PR DESCRIPTION
With the release of my [next-connect](https://github.com/hoangvvo/next-connect), it is now possible to use Connect-style middleware (`function (req, res, next) {}`)

This PR attempts to have the deprecated default export to have this.