### PR TITLE
Fix TypeError when req.header.cookie is undefined or parsed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ const session = (options = {}) => {
 
     //  Try parse cookie if not already
     req.cookies = req.cookies
-  || (req.headers && req.headers.cookie && parseCookie(req.headers.cookie)) || {};
+  || (req.headers && typeof req.headers.cookie === 'string' && parseCookie(req.headers.cookie)) || {};
 
 
     //  Get sessionId cookie from Next.js parsed req.cookies

--- a/src/index.js
+++ b/src/index.js
@@ -77,7 +77,9 @@ const session = (options = {}) => {
     req.sessionStore = store;
 
     //  Try parse cookie if not already
-    req.cookies = req.cookies || (req.headers && parseCookie(req.headers.cookie));
+    req.cookies = req.cookies
+  || (req.headers && req.headers.cookie && parseCookie(req.headers.cookie)) || {};
+
 
     //  Get sessionId cookie from Next.js parsed req.cookies
     req.sessionId = req.cookies[name];


### PR DESCRIPTION
If `req.header.cookie` is not existed, `cookie.parse` will throw a TypeError. Moreover, we also need to make sure that `req.header.cookie` has not been parsed.