### PR TITLE
Use nanoid for default genid config

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ export default withSession(handler, option);
 |---------|-------------|---------|
 | name | The name of the cookie to be read from the request and set to the response. | `sid` |
 | store | The session store instance to be used. | `MemoryStore` |
-| genid | The function that generates a string for a new session ID. | `crypto.randomBytes(16).toString('hex')` |
+| genid | The function that generates a string for a new session ID. | [`nanoid`](https://github.com/ai/nanoid) |
 | touchAfter | Only touch (extend session lifetime despite no modification) after an amount of time to decrease database load. Setting the value to `-1` will disable `touch()`. | `0` (Touch every time) |
 | rolling | Extends the life time of the cookie in the browser if the session is touched. This respects touchAfter. | `false` |
 | autoCommit | Automatically commit session. Disable this if you want to manually `session.commit()` | `true` |

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "react-dom": "^16.6.0"
   },
   "dependencies": {
-    "cookie": "^0.4.0"
+    "cookie": "^0.4.0",
+    "nanoid": "^2.1.11"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepublish": "npm run build",
     "build": "babel src -d dist",
     "lint": "eslint src --ext js --ignore-path .gitignore",
-    "test": "jest --coverageReporters=text-lcov > coverage.lcov"
+    "test": "npm run build && jest --coverageReporters=text-lcov > coverage.lcov"
   },
   "repository": {
     "type": "git",

--- a/src/core.js
+++ b/src/core.js
@@ -1,5 +1,5 @@
 import { parse as parseCookie } from 'cookie';
-import { randomBytes } from 'crypto';
+import nanoid from 'nanoid';
 import MemoryStore from './store/memory';
 import Session from './session';
 import Cookie from './cookie';
@@ -29,10 +29,7 @@ function getOptions(opts = {}) {
     store: opts.store || new MemoryStore(),
     generateId:
       opts.genid ||
-      opts.generateId ||
-      function generateId() {
-        return randomBytes(16).toString('hex');
-      },
+      opts.generateId || nanoid,
     rolling: opts.rolling || false,
     touchAfter: opts.touchAfter ? opts.touchAfter : 0,
     cookie: opts.cookie || {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -5691,6 +5691,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nanoid@^2.1.11:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
+  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
To minimize build size!

Using `crypto`:
```
Page                                                           Size     First Load
┌ λ /apply-session                                             478 B        166 kB
└ λ /with-session                                              399 B        166 kB
+ shared by all                                                57.3 kB
  ├ static/pages/_app.js                                       794 B
  ├ chunks/64a84c3d290ce814047139c07d843b5404496ec0.1e537b.js  2.4 kB
  ├ chunks/c32ab9b3d626257342091fd21a6da1465b6d3e1a.d76621.js  7.96 kB
  ├ chunks/framework.7dc243.js                                 40 kB
  ├ runtime/main.2871e0.js                                     5.44 kB
  └ runtime/webpack.b65cab.js                                  746 B
```

Using `nanoid`:
```
Page                                                           Size     First Load
┌ λ /apply-session                                             478 B       65.4 kB
└ λ /with-session                                              399 B       65.3 kB
+ shared by all                                                57.3 kB
  ├ static/pages/_app.js                                       794 B
  ├ chunks/4e1d99a1554096118a02c0fb82713ba24ff0f999.d76621.js  7.96 kB
  ├ chunks/ce456ad7560d791c2b48bf291aa9299658a2ad30.1e537b.js  2.4 kB
  ├ chunks/framework.7dc243.js                                 40 kB
  ├ runtime/main.2871e0.js                                     5.44 kB
  └ runtime/webpack.b65cab.js                                  746 B
```