### PR TITLE
Add parseId function

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ export default withSession(handler, options);
 | name | The name of the cookie to be read from the request and set to the response. | `sid` |
 | store | The session store instance to be used. | `MemoryStore` |
 | genid | The function that generates a string for a new session ID. | [`nanoid`](https://github.com/ai/nanoid) |
+| parseId | An optional function used to parse the session ID. It can be useful when you have to deal with signed session ID cookies. | unset |
 | touchAfter | Only touch (extend session lifetime despite no modification) after an amount of time to decrease database load. Setting the value to `-1` will disable `touch()`. | `0` (Touch every time) |
 | rolling | Extends the life time of the cookie in the browser if the session is touched. This respects touchAfter. | `false` |
 | autoCommit | Automatically commit session. Disable this if you want to manually `session.commit()` | `true` |

--- a/src/core.js
+++ b/src/core.js
@@ -17,6 +17,7 @@ function getOptions(opts = {}) {
     generateId:
       opts.genid ||
       opts.generateId || nanoid,
+    parseId: opts.parseId,
     rolling: opts.rolling || false,
     touchAfter: opts.touchAfter ? opts.touchAfter : 0,
     cookie: opts.cookie || {},
@@ -38,7 +39,11 @@ export async function applySession(req, res, opts) {
   req.sessionStore = options.store;
 
   if (req.sessionId) {
-    const sess = await req.sessionStore.get(req.sessionId);
+    const sessionId =
+      typeof options.parseId === 'function'
+        ? options.parseId(req.sessionId)
+        : req.sessionId;
+    const sess = await req.sessionStore.get(sessionId);
     if (sess) {
       req.session = new Session(req, res, sess);
       req.session.cookie = new Cookie(sess.cookie);


### PR DESCRIPTION
Add an optional function to parse the session ID. It can be useful to unsign session cookies from other libraries, like [express-session](https://github.com/expressjs/session).

As talked here #50.