### PR TITLE
Add encode/decode options

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ export default withSession(handler, options);
 | name | The name of the cookie to be read from the request and set to the response. | `sid` |
 | store | The session store instance to be used. | `MemoryStore` |
 | genid | The function that generates a string for a new session ID. | [`nanoid`](https://github.com/ai/nanoid) |
+| encodeId | Transforms generated session id before setting cookie. Useful for things like signing. |
+| decodeId | Transforms session id back while getting from cookie |
 | touchAfter | Only touch (extend session lifetime despite no modification) after an amount of time to decrease database load. Setting the value to `-1` will disable `touch()`. | `0` (Touch every time) |
 | rolling | Extends the life time of the cookie in the browser if the session is touched. This respects touchAfter. | `false` |
 | autoCommit | Automatically commit session. Disable this if you want to manually `session.commit()` | `true` |

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ export default withSession(handler, options);
 | name | The name of the cookie to be read from the request and set to the response. | `sid` |
 | store | The session store instance to be used. | `MemoryStore` |
 | genid | The function that generates a string for a new session ID. | [`nanoid`](https://github.com/ai/nanoid) |
-| encodeId | Transforms generated session id before setting cookie. Useful for things like signing. |
-| decodeId | Transforms session id back while getting from cookie |
+| encode | Transforms session ID before setting cookie. Useful for things like signing or encrypting. | undefined |
+| decode | Transforms session ID back while getting from cookie | undefined |
 | touchAfter | Only touch (extend session lifetime despite no modification) after an amount of time to decrease database load. Setting the value to `-1` will disable `touch()`. | `0` (Touch every time) |
 | rolling | Extends the life time of the cookie in the browser if the session is touched. This respects touchAfter. | `false` |
 | autoCommit | Automatically commit session. Disable this if you want to manually `session.commit()` | `true` |

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ const signature = require('cookie-signature');
 const secret = 'keyboard cat';
 session({
   encode: (raw) => signature.unsign(raw.slice(2), secret),
-  decode: (sid) => (sessId ? 's:' + signature.sign(sid, secret) : null),
+  decode: (sid) => (sid ? 's:' + signature.sign(sid, secret) : null),
 });
 
 // async function is also supported

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ export default withSession(handler, options);
 | name | The name of the cookie to be read from the request and set to the response. | `sid` |
 | store | The session store instance to be used. | `MemoryStore` |
 | genid | The function that generates a string for a new session ID. | [`nanoid`](https://github.com/ai/nanoid) |
-| encode | Transforms session ID before setting cookie. Useful for things like signing or encrypting. | undefined |
-| decode | Transforms session ID back while getting from cookie | undefined |
+| encode | Transforms session ID before setting cookie. It takes the raw session ID and returns the decoded/decrypted session ID. | undefined |
+| decode | Transforms session ID back while getting from cookie. It should return the encoded/encrypted session ID | undefined |
 | touchAfter | Only touch (extend session lifetime despite no modification) after an amount of time to decrease database load. Setting the value to `-1` will disable `touch()`. | `0` (Touch every time) |
 | rolling | Extends the life time of the cookie in the browser if the session is touched. This respects touchAfter. | `false` |
 | autoCommit | Automatically commit session. Disable this if you want to manually `session.commit()` | `true` |
@@ -178,6 +178,22 @@ export default withSession(handler, options);
 | cookie.domain | Specifies the value for the **Domain** `Set-Cookie` attribute. | unset |
 | cookie.sameSite | Specifies the value for the **SameSite** `Set-Cookie` attribute. | unset |
 | cookie.maxAge | **(in seconds)** Specifies the value for the **Max-Age** `Set-Cookie` attribute. | unset (Browser session) |
+
+#### encode/decode
+
+You may supply a custom pair of function that *encode/decode* or *encrypt/decrypt* the cookie on every request.
+
+```javascript
+// `express-session` signing strategy
+const signature = require('cookie-signature');
+const secret = 'keyboard cat';
+session({
+  encode: (raw) => signature.unsign(raw.slice(2), secret),
+  decode: (sid) => (sessId ? 's:' + signature.sign(sid, secret) : null),
+});
+
+// async function is also supported
+```
 
 ### req.session
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/core": "^7.8.3",
     "@babel/preset-env": "^7.8.3",
     "babel-jest": "^25.1.0",
+    "cookie-signature": "^1.1.0",
     "cross-spawn": "^7.0.1",
     "eslint": "^6.8.0",
     "eslint-plugin-react": "^7.18.0",

--- a/src/core.js
+++ b/src/core.js
@@ -35,9 +35,9 @@ export async function applySession(req, res, opts) {
     req.headers && req.headers.cookie
       ? parseCookie(req.headers.cookie)[options.name]
       : null;
-  req._sessId = 
+  req._sessId =
     req.sessionId = rawSessionId && typeof options.decode === 'function'
-      ? options.decode(rawSessionId)
+      ? await options.decode(rawSessionId)
       : rawSessionId;
   req._sessOpts = options;
 

--- a/src/core.js
+++ b/src/core.js
@@ -17,6 +17,8 @@ function getOptions(opts = {}) {
     generateId:
       opts.genid ||
       opts.generateId || nanoid,
+    encode: opts.encode,
+    decode: opts.decode,
     rolling: opts.rolling || false,
     touchAfter: opts.touchAfter ? opts.touchAfter : 0,
     cookie: opts.cookie || {},
@@ -29,10 +31,14 @@ export async function applySession(req, res, opts) {
 
   if (req.session) return;
 
-  req._sessId = req.sessionId =
+  const rawSessionId =
     req.headers && req.headers.cookie
       ? parseCookie(req.headers.cookie)[options.name]
       : null;
+  req._sessId = 
+    req.sessionId = rawSessionId && typeof options.decode === 'function'
+      ? options.decode(rawSessionId)
+      : rawSessionId;
   req._sessOpts = options;
 
   req.sessionStore = options.store;

--- a/src/session.js
+++ b/src/session.js
@@ -59,9 +59,13 @@ export default class Session {
     }
     if (shouldSetCookie()) {
       if (this.res.headersSent) return;
+      const sessionId =
+        typeof this.req._sessOpts.encode === 'function'
+          ? this.req._sessOpts.encode(this.req.sessionId)
+          : this.req.sessionId
       this.res.setHeader(
         'Set-Cookie',
-        this.cookie.serialize(name, this.req.sessionId)
+        this.cookie.serialize(name, sessionId)
       );
     }
   }

--- a/src/session.js
+++ b/src/session.js
@@ -61,7 +61,7 @@ export default class Session {
       if (this.res.headersSent) return;
       const sessionId =
         typeof this.req._sessOpts.encode === 'function'
-          ? this.req._sessOpts.encode(this.req.sessionId)
+          ? await this.req._sessOpts.encode(this.req.sessionId)
           : this.req.sessionId
       this.res.setHeader(
         'Set-Cookie',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2441,6 +2441,11 @@ convert-source-map@^0.3.3:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-0.3.5.tgz#f1d802950af7dd2631a1febe0596550c86ab3190"
   integrity sha1-8dgClQr33SYxof6+BZZVDIarMZA=
 
+cookie-signature@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.1.0.tgz#cc94974f91fb9a9c1bb485e95fc2b7f4b120aff2"
+  integrity sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A==
+
 cookie@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"


### PR DESCRIPTION
Use case in mind was to support `express-session` signing behavior so `next-session` and `express-session` can share the same session.

Original discussion started [here](https://github.com/hoangvvo/next-session/issues/50) and continued [here](https://github.com/hoangvvo/next-session/pull/110).