### PR TITLE
Add new compatible layer for express-session stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ const options = {
 withSession(handler, options);
 ```
 
-Some stores may requires `MemoryStore` and `Store` from `next-session`. For example:
+Some stores may requires `session` from `express-session`. For example:
 
 ```javascript
 // If a store has a pattern like this...

--- a/README.md
+++ b/README.md
@@ -264,9 +264,9 @@ Some stores may requires `MemoryStore` and `Store` from `next-session`. For exam
 // If a store has a pattern like this...
 const MongoStore = require('connect-mongo')(session);
 
-// ...import Store and MemoryStore from next-session and use them like so:
-import { Store, MemoryStore, promisifyStore } from "next-session";
-const MongoStore = require('connect-mongo')({ Store, MemoryStore });
+// ...import expressSession from next-session and use them like so:
+import { expressSession, promisifyStore } from "next-session";
+const MongoStore = require('connect-mongo')(expressSession);
 const options = {
   store: promisifyStore(new MongoStore(options))
 }

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -1,4 +1,4 @@
-import { promisify, inherits } from 'util';
+import { promisify, callbackify, inherits } from 'util';
 import { EventEmitter } from 'events';
 import { Store as ExpressStore }from 'express-session';
 import { StoreInterface } from './types';
@@ -17,7 +17,15 @@ function expressSession(options?: any): any {
 }
 
 expressSession.Store = Store;
-expressSession.MemoryStore = MemoryStore;
+
+function CallbackMemoryStore() {}
+inherits(CallbackMemoryStore, Store);
+CallbackMemoryStore.prototype.get = callbackify(MemoryStore.prototype.get);
+CallbackMemoryStore.prototype.set = callbackify(MemoryStore.prototype.set);
+CallbackMemoryStore.prototype.destroy = callbackify(MemoryStore.prototype.destroy);
+CallbackMemoryStore.prototype.all = callbackify(MemoryStore.prototype.all);
+
+expressSession.MemoryStore = CallbackMemoryStore;
 
 export { expressSession };
 

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -1,9 +1,8 @@
 import { promisify, callbackify, inherits } from 'util';
 import { EventEmitter } from 'events';
 import { Store as ExpressStore }from 'express-session';
-import { StoreInterface } from './types';
-import session from './connect';
-import { MemoryStore } from '.';
+import { IStore } from './types';
+import MemoryStore from './store/memory';
 
 function Store() {
   // @ts-ignore
@@ -12,9 +11,7 @@ function Store() {
 inherits(Store, EventEmitter);
 // no-op for compat
 
-function expressSession(options?: any): any {
-  return session(options);
-}
+function expressSession(options?: any): any {}
 
 expressSession.Store = Store;
 
@@ -29,10 +26,10 @@ expressSession.MemoryStore = CallbackMemoryStore;
 
 export { expressSession };
 
-export function promisifyStore(store: Pick<ExpressStore, 'get' | 'destroy' | 'set'> & Partial<ExpressStore>): StoreInterface {
+export function promisifyStore(store: Pick<ExpressStore, 'get' | 'destroy' | 'set'> & Partial<ExpressStore>): IStore {
   store.get = promisify(store.get);
   store.set = promisify(store.set);
   store.destroy = promisify(store.destroy);
   if (typeof store.touch === 'function') store.touch = promisify(store.touch);
-  return store as StoreInterface;
+  return store as IStore;
 }

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -1,6 +1,6 @@
 import { promisify, callbackify, inherits } from 'util';
 import { EventEmitter } from 'events';
-import { Store as ExpressStore }from 'express-session';
+import { Store as ExpressStore } from 'express-session';
 import { IStore } from './types';
 import MemoryStore from './store/memory';
 
@@ -19,14 +19,18 @@ function CallbackMemoryStore() {}
 inherits(CallbackMemoryStore, Store);
 CallbackMemoryStore.prototype.get = callbackify(MemoryStore.prototype.get);
 CallbackMemoryStore.prototype.set = callbackify(MemoryStore.prototype.set);
-CallbackMemoryStore.prototype.destroy = callbackify(MemoryStore.prototype.destroy);
+CallbackMemoryStore.prototype.destroy = callbackify(
+  MemoryStore.prototype.destroy
+);
 CallbackMemoryStore.prototype.all = callbackify(MemoryStore.prototype.all);
 
 expressSession.MemoryStore = CallbackMemoryStore;
 
 export { expressSession };
 
-export function promisifyStore(store: Pick<ExpressStore, 'get' | 'destroy' | 'set'> & Partial<ExpressStore>): IStore {
+export function promisifyStore(
+  store: Pick<ExpressStore, 'get' | 'destroy' | 'set'> & Partial<ExpressStore>
+): IStore {
   store.get = promisify(store.get);
   store.set = promisify(store.set);
   store.destroy = promisify(store.destroy);

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -2,6 +2,8 @@ import { promisify, inherits } from 'util';
 import { EventEmitter } from 'events';
 import { Store as ExpressStore }from 'express-session';
 import { StoreInterface } from './types';
+import session from './connect';
+import { MemoryStore } from '.';
 
 function Store() {
   // @ts-ignore
@@ -10,7 +12,14 @@ function Store() {
 inherits(Store, EventEmitter);
 // no-op for compat
 
-export { Store };
+function expressSession(options?: any): any {
+  return session(options);
+}
+
+expressSession.Store = Store;
+expressSession.MemoryStore = MemoryStore;
+
+export { expressSession };
 
 export function promisifyStore(store: Pick<ExpressStore, 'get' | 'destroy' | 'set'> & Partial<ExpressStore>): StoreInterface {
   store.get = promisify(store.get);

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -4,7 +4,11 @@ import { CookieOptions, SessionCookieData } from './types';
 declare interface Cookie extends SessionCookieData {}
 
 class Cookie {
-  constructor(options: (CookieOptions | SessionCookieData) & { expires?: Date | string | null }) {
+  constructor(
+    options: (CookieOptions | SessionCookieData) & {
+      expires?: Date | string | null;
+    }
+  ) {
     //  Set parameters
     this.path = options.path || '/';
     this.maxAge = options.maxAge || null;
@@ -14,7 +18,10 @@ class Cookie {
     this.secure = options.secure || false;
     // set expires based on maxAge (in seconds)
     if (options.expires)
-      this.expires = typeof options.expires === 'string' ? new Date(options.expires) : options.expires;
+      this.expires =
+        typeof options.expires === 'string'
+          ? new Date(options.expires)
+          : options.expires;
     else if (this.maxAge)
       this.expires = new Date(Date.now() + this.maxAge * 1000);
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -2,12 +2,7 @@ import { parse as parseCookie } from 'cookie';
 import { nanoid } from 'nanoid';
 import MemoryStore from './store/memory';
 import Session from './session';
-import {
-  Options,
-  Request,
-  Response,
-  SessionOptions,
-} from './types';
+import { Options, Request, Response, SessionOptions } from './types';
 
 export function stringify(sess: Session) {
   return JSON.stringify(sess, (key, val) =>

--- a/src/extendedRequest.d.ts
+++ b/src/extendedRequest.d.ts
@@ -1,6 +1,6 @@
-import { Session, IStore, SessionOptions } from ".";
+import { Session, IStore, SessionOptions } from '.';
 
-declare module "http" {
+declare module 'http' {
   export interface IncomingMessage {
     sessionId?: string | null;
     _sessId?: string | null;

--- a/src/extendedRequest.d.ts
+++ b/src/extendedRequest.d.ts
@@ -1,4 +1,4 @@
-import { Session, StoreInterface, SessionOptions } from ".";
+import { Session, IStore, SessionOptions } from ".";
 
 declare module "http" {
   export interface IncomingMessage {
@@ -7,6 +7,6 @@ declare module "http" {
     session: Session;
     _sessOpts: SessionOptions;
     _sessStr: string;
-    sessionStore: StoreInterface;
+    sessionStore: IStore;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,6 @@ export { default as withSession } from './withSession';
 export { default as session } from './connect';
 export { applySession } from './core';
 export { default as MemoryStore } from './store/memory';
-export { promisifyStore, Store } from './compat';
+export { promisifyStore, expressSession } from './compat';
 export { default as Session } from './session';
 export * from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 export { default as withSession } from './withSession';
 export { default as session } from './connect';
 export { applySession } from './core';
-export { default as MemoryStore } from './store/memory';
 export { promisifyStore, expressSession } from './compat';
-export { default as Session } from './session';
 export * from './types';

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -1,9 +1,9 @@
-import { StoreInterface, SessionData } from '../types';
+import { IStore, SessionData } from '../types';
 import { EventEmitter } from 'events';
 const MemoryStoreSession = {};
 
 export default class MemoryStore extends EventEmitter
-  implements StoreInterface {
+  implements IStore {
   sessions: Record<string, string>;
   constructor() {
     super();

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -2,8 +2,7 @@ import { IStore, SessionData } from '../types';
 import { EventEmitter } from 'events';
 const MemoryStoreSession = {};
 
-export default class MemoryStore extends EventEmitter
-  implements IStore {
+export default class MemoryStore extends EventEmitter implements IStore {
   sessions: Record<string, string>;
   constructor() {
     super();
@@ -16,7 +15,9 @@ export default class MemoryStore extends EventEmitter
     const sess = this.sessions[sid];
     if (sess) {
       const session = JSON.parse(sess);
-      session.cookie.expires = session.cookie.expires ? new Date(session.cookie.expires) : null;
+      session.cookie.expires = session.cookie.expires
+        ? new Date(session.cookie.expires)
+        : null;
 
       if (
         !session.cookie.expires ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface SessionCookieData {
   expires?: Date;
 }
 
-export abstract class StoreInterface {
+export abstract class IStore {
   abstract get: (sid: string) => Promise<SessionData | null>;
   abstract set: (sid: string, sess: SessionData) => Promise<void>;
   abstract destroy: (sid: string) => Promise<void>;
@@ -36,7 +36,7 @@ export interface CookieOptions {
 
 export interface Options {
   name?: string;
-  store?: StoreInterface;
+  store?: IStore;
   genid?: () => string;
   encode?: (rawSid: string) => string;
   decode?: (encryptedSid: string) => string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 export type SessionData = {
   [key: string]: any;
   cookie: SessionCookieData;
-}
+};
 
 export interface SessionCookieData {
   path: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 /// <reference path="./extendedRequest.d.ts" />
 import { IncomingMessage, ServerResponse } from 'http';
-import { NextApiRequest, NextApiResponse } from 'next';
 
 export type SessionData = {
   [key: string]: any;
@@ -60,6 +59,6 @@ export type SessionOptions = Pick<
   decode?: (encryptedSid: string) => string;
 };
 
-export type Request = IncomingMessage | NextApiRequest;
+export type Request = IncomingMessage;
 
-export type Response = ServerResponse | NextApiResponse;
+export type Response = ServerResponse;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -246,7 +246,7 @@ describe('Store', () => {
   });
   test('should extend EventEmitter', () => {
     // @ts-ignore
-    expect(new Store()).toBeInstanceOf(EventEmitter);
+    expect(new expressSession.Store()).toBeInstanceOf(EventEmitter);
   });
   test('should allow store subclasses to use Store.call(this)', () => {
     // Some express-compatible stores use this pattern like

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,15 +6,15 @@ import EventEmitter from 'events';
 import { parse } from 'url';
 import {
   applySession,
-  MemoryStore,
   promisifyStore,
   withSession,
   session,
   Options,
   SessionData,
-  Session,
   expressSession
 } from '../src';
+import MemoryStore from '../src/store/memory';
+import Session from '../src/session';
 import Cookie from '../src/cookie';
 import { ServerResponse } from 'http';
 import { IncomingMessage } from 'http';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,14 +6,14 @@ import EventEmitter from 'events';
 import { parse } from 'url';
 import {
   applySession,
-  Store,
   MemoryStore,
   promisifyStore,
   withSession,
   session,
   Options,
   SessionData,
-  Session
+  Session,
+  expressSession
 } from '../src';
 import Cookie from '../src/cookie';
 import { ServerResponse } from 'http';
@@ -253,7 +253,7 @@ describe('Store', () => {
     // https://github.com/voxpelli/node-connect-pg-simple/blob/master/index.js
     function SubStore() {
       // @ts-ignore
-      Store.call(this);
+      expressSession.Store.call(this);
     }
     // eslint-disable-next-line no-unused-vars
     // @ts-ignore


### PR DESCRIPTION
Currently the approach for compatible layer for express-session stores is to fill in `MemoryStore` and `Store`. This may be confusing.

This PR add the new named export `expressSession`