### PR TITLE
Avoid mutation to `req` and add `session.isNew`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,12 @@ export default async function handler(req, res) {
 
 `next-session` does not work in [Custom App](https://nextjs.org/docs/advanced-features/custom-app) since it leads to deoptimization.
 
-#### `{ withSession }` ([`getInitialProps`](https://nextjs.org/docs/api-reference/data-fetching/getInitialProps))
+#### ~~`{ withSession }` ([`getInitialProps`](https://nextjs.org/docs/api-reference/data-fetching/getInitialProps))~~
 
-*Note: This usage is not recommended. `next@>9.3.0` recommends using `getServerSideProps` instead of `getInitialProps`.*
-**This will work on [server only](https://nextjs.org/docs/api-reference/data-fetching/getInitialProps#context-object) (first render)**.
+**This will be deprecated in the next major release!**
+
+> `next@>9.3.0` recommends using `getServerSideProps` instead of `getInitialProps`.
+> Also, it is not reliable since `req` or `req.session` is only available on [server only](https://nextjs.org/docs/api-reference/data-fetching/getInitialProps#context-object)
 
 ```javascript
 import { withSession } from 'next-session';
@@ -124,8 +126,6 @@ Page.getInitialProps = ({ req }) => {
 
 export default withSession(Page, options);
 ```
-
-If you want session to always be available, consider using `{ applySession }` in `getServerSideProps`.
 
 #### `{ applySession }` ([`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering))
 

--- a/README.md
+++ b/README.md
@@ -239,6 +239,10 @@ await req.session.commit();
 
 The unique id that associates to the current session.
 
+### req.session.isNew
+
+Return *true* if the session is new.
+
 ## Session Store
 
 The session store to use for session middleware (see `options` above).

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -1,7 +1,7 @@
 import { promisify, callbackify, inherits } from 'util';
 import { EventEmitter } from 'events';
 import { Store as ExpressStore } from 'express-session';
-import { IStore } from './types';
+import { SessionStore } from './types';
 import MemoryStore from './store/memory';
 
 export function Store() {
@@ -30,10 +30,10 @@ export { expressSession };
 
 export function promisifyStore(
   store: Pick<ExpressStore, 'get' | 'destroy' | 'set'> & Partial<ExpressStore>
-): IStore {
+): SessionStore {
   store.get = promisify(store.get);
   store.set = promisify(store.set);
   store.destroy = promisify(store.destroy);
   if (typeof store.touch === 'function') store.touch = promisify(store.touch);
-  return store as IStore;
+  return store as SessionStore;
 }

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -5,7 +5,7 @@ let storeReady = true;
 
 export default function session(opts?: Options) {
   //  store readiness
-  if (opts?.store?.on) {
+  if (opts && opts.store && opts.store.on) {
     opts.store.on('disconnect', () => {
       storeReady = false;
     });

--- a/src/core.ts
+++ b/src/core.ts
@@ -36,8 +36,6 @@ export async function applySession(
     req.sessionId = await options.decode(req.sessionId)
   }
 
-  req._sessId = req.sessionId;
-
   req.sessionStore = options.store;
 
   req.session = new Session(req, res, req.sessionId ? await req.sessionStore.get(req.sessionId) : null , options)

--- a/src/core.ts
+++ b/src/core.ts
@@ -27,7 +27,7 @@ export async function applySession(
 
   if (req.session) return;
 
-  req.sessionId = req.headers?.cookie
+  req.sessionId = req.headers && req.headers.cookie
     ? parseCookie(req.headers.cookie)[options.name]
     : null;
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -27,18 +27,22 @@ export async function applySession(
 
   if (req.session) return;
 
-  req.sessionId =
-    req.headers?.cookie
-      ? parseCookie(req.headers.cookie)[options.name]
-      : null;
+  req.sessionId = req.headers?.cookie
+    ? parseCookie(req.headers.cookie)[options.name]
+    : null;
 
   if (req.sessionId && typeof options.decode === 'function') {
-    req.sessionId = await options.decode(req.sessionId)
+    req.sessionId = await options.decode(req.sessionId);
   }
 
   req.sessionStore = options.store;
 
-  req.session = new Session(req, res, req.sessionId ? await req.sessionStore.get(req.sessionId) : null , options)
+  req.session = new Session(
+    req,
+    res,
+    req.sessionId ? await req.sessionStore.get(req.sessionId) : null,
+    options
+  );
 
   // autocommit
   if (options.autoCommit) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -50,8 +50,6 @@ export async function applySession(
     req.session = new Session(req, res, null, options);
   }
 
-  req.sessionId = req.session.id;
-
   // autocommit
   if (options.autoCommit) {
     const oldEnd = res.end;

--- a/src/core.ts
+++ b/src/core.ts
@@ -18,12 +18,6 @@ function getOptions(opts: Options = {}): SessionOptions {
   };
 }
 
-function stringify(sess: Session) {
-  return JSON.stringify(sess, (key, val) =>
-    key === 'cookie' ? undefined : val
-  );
-}
-
 export async function applySession(
   req: Request,
   res: Response,
@@ -44,21 +38,19 @@ export async function applySession(
 
   req._sessId = req.sessionId;
 
-  req._sessOpts = options;
-
   req.sessionStore = options.store;
 
   if (req.sessionId) {
     const sess = await req.sessionStore.get(req.sessionId);
-    if (sess) req.session = new Session(req, res, sess);
+    if (sess) req.session = new Session(req, res, sess, options);
   }
 
   if (!req.session) {
     req.sessionId = options.genid();
-    req.session = new Session(req, res);
+    req.session = new Session(req, res, null, options);
   }
 
-  req._sessStr = stringify(req.session);
+  req.sessionId = req.session.id;
 
   // autocommit
   if (options.autoCommit) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -40,15 +40,7 @@ export async function applySession(
 
   req.sessionStore = options.store;
 
-  if (req.sessionId) {
-    const sess = await req.sessionStore.get(req.sessionId);
-    if (sess) req.session = new Session(req, res, sess, options);
-  }
-
-  if (!req.session) {
-    req.sessionId = options.genid();
-    req.session = new Session(req, res, null, options);
-  }
+  req.session = new Session(req, res, req.sessionId ? await req.sessionStore.get(req.sessionId) : null , options)
 
   // autocommit
   if (options.autoCommit) {

--- a/src/extendedRequest.d.ts
+++ b/src/extendedRequest.d.ts
@@ -2,11 +2,9 @@ import { Session, IStore, SessionOptions } from '.';
 
 declare module 'http' {
   export interface IncomingMessage {
-    sessionId?: string | null;
-    _sessId?: string | null;
+    sessionId: string | null;
+    _sessId: string | null;
     session: Session;
-    _sessOpts: SessionOptions;
-    _sessStr: string;
     sessionStore: IStore;
   }
 }

--- a/src/extendedRequest.d.ts
+++ b/src/extendedRequest.d.ts
@@ -1,9 +1,9 @@
-import { Session, IStore, SessionOptions } from '.';
+import { Session, SessionStore, SessionOptions } from '.';
 
 declare module 'http' {
   export interface IncomingMessage {
     sessionId: string | null;
     session: Session;
-    sessionStore: IStore;
+    sessionStore: SessionStore;
   }
 }

--- a/src/extendedRequest.d.ts
+++ b/src/extendedRequest.d.ts
@@ -3,7 +3,6 @@ import { Session, IStore, SessionOptions } from '.';
 declare module 'http' {
   export interface IncomingMessage {
     sessionId: string | null;
-    _sessId: string | null;
     session: Session;
     sessionStore: IStore;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,4 @@ export { default as session } from './connect';
 export { applySession } from './core';
 export { promisifyStore, expressSession, Store } from './compat';
 export { default as MemoryStore } from './store/memory';
-export * from './types';
+export { SessionData, SessionCookieData, SessionStore } from './types';

--- a/src/session.ts
+++ b/src/session.ts
@@ -21,9 +21,11 @@ class Session {
   cookie: Cookie;
   //[key: string]: any;
   constructor(req: Request, res: Response, sess: SessionData | null, options: SessionOptions) {
-    Object.defineProperty(this, 'req', { value: req });
-    Object.defineProperty(this, 'res', { value: res });
-    Object.defineProperty(this, '_opts', { value: options });
+    Object.defineProperties(this, {
+      req: { value: req },
+      res: { value: res },
+      _opts: { value: options }
+    })
     let isNew = false;
     if (sess) {
       Object.assign(this, sess);
@@ -34,9 +36,11 @@ class Session {
       this.cookie = new Cookie(this._opts.cookie);
       req.sessionId = options.genid();
     }
-    Object.defineProperty(this, 'isNew', {value: isNew })
-    Object.defineProperty(this, 'id', { value: req.sessionId });
-    Object.defineProperty(this, '_sessStr', { value: stringify(this) })
+    Object.defineProperties(this, {
+      isNew: { value: isNew },
+      id: { value: req.sessionId },
+      _sessStr: { value: stringify(this) }
+    })
   }
 
   //  touch the session

--- a/src/session.ts
+++ b/src/session.ts
@@ -30,19 +30,18 @@ class Session {
       req: { value: req },
       res: { value: res },
       _opts: { value: options },
+      isNew: { value: false, writable: true }
     });
-    let isNew = false;
     if (sess) {
       Object.assign(this, sess);
       this.cookie = new Cookie(sess.cookie);
     } else {
-      isNew = true;
+      this.isNew = true;
       // Create new session
       this.cookie = new Cookie(this._opts.cookie);
       req.sessionId = options.genid();
     }
     Object.defineProperties(this, {
-      isNew: { value: isNew },
       id: { value: req.sessionId },
       _sessStr: { value: stringify(this) },
     });
@@ -65,6 +64,7 @@ class Session {
   }
 
   destroy() {
+    this.isNew = true;
     delete this.req.session;
     return this._opts.store.destroy(this.id);
   }

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,5 +1,6 @@
 import { Request, Response, SessionData } from './types';
 import Cookie from './cookie';
+import { SessionOptions } from '.';
 
 function stringify(sess: Session) {
   return JSON.stringify(sess, (key, val) =>
@@ -11,29 +12,33 @@ declare interface Session {
   id: string;
   req: Request;
   res: Response;
+  _opts: SessionOptions;
+  _sessStr: string;
 }
 
 class Session {
   cookie: Cookie;
-  [key: string]: any;
-  constructor(req: Request, res: Response, sess?: SessionData) {
+  //[key: string]: any;
+  constructor(req: Request, res: Response, sess: SessionData | null, options: SessionOptions) {
     Object.defineProperty(this, 'id', { value: req.sessionId });
     Object.defineProperty(this, 'req', { value: req });
     Object.defineProperty(this, 'res', { value: res });
+    Object.defineProperty(this, '_opts', { value: options });
     if (sess) {
       Object.assign(this, sess);
       this.cookie = new Cookie(sess.cookie);
     } else {
-      this.cookie = new Cookie(req._sessOpts.cookie);
+      this.cookie = new Cookie(this._opts.cookie);
     }
+    Object.defineProperty(this, '_sessStr', { value: stringify(this) })
   }
 
   //  touch the session
   touch() {
     this.cookie.resetExpires();
     //  check if store supports touch()
-    if (typeof this.req.sessionStore.touch === 'function') {
-      return this.req.sessionStore.touch(this.id, this);
+    if (typeof this._opts.store.touch === 'function') {
+      return this._opts.store.touch(this.id, this);
     }
     return Promise.resolve();
   }
@@ -41,20 +46,20 @@ class Session {
   //  sessionStore to set this Session
   save() {
     this.cookie.resetExpires();
-    return this.req.sessionStore.set(this.id, this);
+    return this._opts.store.set(this.id, this);
   }
 
   destroy() {
     delete this.req.session;
-    return this.req.sessionStore.destroy(this.id);
+    return this._opts.store.destroy(this.id);
   }
 
   async commit() {
-    const { name, rolling, touchAfter } = this.req._sessOpts;
+    const { name, rolling, touchAfter } = this._opts;
     let touched = false;
     let saved = false;
 
-    const shouldSave = () => stringify(this) !== this.req._sessStr;
+    const shouldSave = () => stringify(this) !== this._sessStr;
     const shouldTouch = () => {
       if (!this.cookie.maxAge || !this.cookie.expires || touchAfter === -1)
         return false;
@@ -79,8 +84,8 @@ class Session {
     if (shouldSetCookie()) {
       if (this.res.headersSent) return;
       const sessionId =
-        typeof this.req._sessOpts.encode === 'function'
-          ? await this.req._sessOpts.encode(this.id)
+        typeof this._opts.encode === 'function'
+          ? await this._opts.encode(this.id)
           : this.id;
       this.res.setHeader('Set-Cookie', this.cookie.serialize(name, sessionId));
     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,6 +1,6 @@
 import { Request, Response, SessionData } from './types';
 import Cookie from './cookie';
-import { SessionOptions } from '.';
+import { SessionOptions } from './types';
 
 function stringify(sess: Session) {
   return JSON.stringify(sess, (key, val) =>

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,6 +1,11 @@
-import { stringify } from './core';
 import { Request, Response, SessionData } from './types';
 import Cookie from './cookie';
+
+function stringify(sess: Session) {
+  return JSON.stringify(sess, (key, val) =>
+    key === 'cookie' ? undefined : val
+  );
+}
 
 declare interface Session {
   id: string;

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,6 +14,7 @@ declare interface Session {
   res: Response;
   _opts: SessionOptions;
   _sessStr: string;
+  isNew: boolean;
 }
 
 class Session {
@@ -23,14 +24,17 @@ class Session {
     Object.defineProperty(this, 'req', { value: req });
     Object.defineProperty(this, 'res', { value: res });
     Object.defineProperty(this, '_opts', { value: options });
+    let isNew = false;
     if (sess) {
       Object.assign(this, sess);
       this.cookie = new Cookie(sess.cookie);
     } else {
+      isNew = true;
       // Create new session
       this.cookie = new Cookie(this._opts.cookie);
       req.sessionId = options.genid();
     }
+    Object.defineProperty(this, 'isNew', {value: isNew })
     Object.defineProperty(this, 'id', { value: req.sessionId });
     Object.defineProperty(this, '_sessStr', { value: stringify(this) })
   }
@@ -70,7 +74,7 @@ class Session {
         (this.cookie.expires.getTime() - Date.now());
       return elapsed >= touchAfter;
     };
-    const shouldSetCookie = () => (rolling && touched) || this.req._sessId !== this.id
+    const shouldSetCookie = () => (rolling && touched) || this.isNew;
 
     if (shouldSave()) {
       saved = true;

--- a/src/session.ts
+++ b/src/session.ts
@@ -20,7 +20,6 @@ class Session {
   cookie: Cookie;
   //[key: string]: any;
   constructor(req: Request, res: Response, sess: SessionData | null, options: SessionOptions) {
-    Object.defineProperty(this, 'id', { value: req.sessionId });
     Object.defineProperty(this, 'req', { value: req });
     Object.defineProperty(this, 'res', { value: res });
     Object.defineProperty(this, '_opts', { value: options });
@@ -28,8 +27,11 @@ class Session {
       Object.assign(this, sess);
       this.cookie = new Cookie(sess.cookie);
     } else {
+      // Create new session
       this.cookie = new Cookie(this._opts.cookie);
+      req.sessionId = options.genid();
     }
+    Object.defineProperty(this, 'id', { value: req.sessionId });
     Object.defineProperty(this, '_sessStr', { value: stringify(this) })
   }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -68,10 +68,7 @@ class Session {
         (this.cookie.expires.getTime() - Date.now());
       return elapsed >= touchAfter;
     };
-    const shouldSetCookie = () => {
-      if (rolling && touched) return true;
-      return this.req._sessId !== this.id;
-    };
+    const shouldSetCookie = () => (rolling && touched) || this.req._sessId !== this.id
 
     if (shouldSave()) {
       saved = true;

--- a/src/session.ts
+++ b/src/session.ts
@@ -19,7 +19,7 @@ declare interface Session {
 
 class Session {
   cookie: Cookie;
-  //[key: string]: any;
+  [key: string]: any;
   constructor(
     req: Request,
     res: Response,

--- a/src/session.ts
+++ b/src/session.ts
@@ -73,24 +73,24 @@ class Session {
     const { name, rolling, touchAfter } = this._opts;
     let touched = false;
     let saved = false;
-
-    const shouldSave = stringify(this) !== this._sessStr;
-    const shouldTouch =
-      this.cookie.maxAge !== null &&
-      this.cookie.expires &&
-      touchAfter === -1 &&
-      this.cookie.maxAge * 1000 -
-        (this.cookie.expires.getTime() - Date.now()) >=
-        touchAfter;
-
-    if (shouldSave) {
+    // Check if session is mutated
+    if (stringify(this) !== this._sessStr) {
       saved = true;
       await this.save();
     }
+    const shouldTouch =
+      touchAfter !== -1 &&
+      this.cookie.maxAge !== null &&
+      this.cookie.expires &&
+      // Session must be older than touchAfter
+      this.cookie.maxAge * 1000 -
+        (this.cookie.expires.getTime() - Date.now()) >=
+        touchAfter;
     if (!saved && shouldTouch) {
       touched = true;
       await this.touch();
     }
+    // Check if new cookie should be set
     if ((rolling && touched) || this.isNew) {
       if (this.res.headersSent) return;
       this.res.setHeader(

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -1,8 +1,8 @@
-import { IStore, SessionData } from '../types';
+import { SessionStore, SessionData } from '../types';
 import { EventEmitter } from 'events';
 const MemoryStoreSession = {};
 
-export default class MemoryStore extends EventEmitter implements IStore {
+export default class MemoryStore extends EventEmitter implements SessionStore {
   sessions: Record<string, string>;
   constructor() {
     super();

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export interface SessionCookieData {
   expires?: Date;
 }
 
-export abstract class IStore {
+export abstract class SessionStore {
   abstract get: (sid: string) => Promise<SessionData | null>;
   abstract set: (sid: string, sess: SessionData) => Promise<void>;
   abstract destroy: (sid: string) => Promise<void>;
@@ -35,7 +35,7 @@ export interface CookieOptions {
 
 export interface Options {
   name?: string;
-  store?: IStore;
+  store?: SessionStore;
   genid?: () => string;
   encode?: (rawSid: string) => string;
   decode?: (encryptedSid: string) => string;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -11,7 +11,7 @@ import {
   session,
   Options,
   SessionData,
-  expressSession
+  expressSession,
 } from '../src';
 import MemoryStore from '../src/store/memory';
 import Session from '../src/session';
@@ -20,7 +20,7 @@ import { ServerResponse } from 'http';
 import { IncomingMessage } from 'http';
 import { NextPage, NextApiHandler, NextComponentType } from 'next';
 const signature = require('cookie-signature');
-const { parse: parseCookie } = require('cookie')
+const { parse: parseCookie } = require('cookie');
 
 const defaultHandler = (req: IncomingMessage, res: ServerResponse) => {
   if (req.method === 'POST')
@@ -29,7 +29,11 @@ const defaultHandler = (req: IncomingMessage, res: ServerResponse) => {
   res.end(`${(req.session && req.session.views) || 0}`);
 };
 
-function setUpServer(handler: RequestListener = defaultHandler, options?: boolean | Options, prehandler?: (req: IncomingMessage, res: ServerResponse) => any) {
+function setUpServer(
+  handler: RequestListener = defaultHandler,
+  options?: boolean | Options,
+  prehandler?: (req: IncomingMessage, res: ServerResponse) => any
+) {
   const server = createServer(async (req, res) => {
     if (prehandler) await prehandler(req, res);
     if (options !== false) await applySession(req, res, options as Options);
@@ -137,8 +141,10 @@ describe('applySession', () => {
     const badSecret = 'nyan cat';
     const store = new MemoryStore();
 
-    const decodeFn = (key: string) => (raw: string) => signature.unsign(raw.slice(2), key);
-    const encodeFn = (key: string) => (sessId: string) => sessId && `s:${signature.sign(sessId, key)}`
+    const decodeFn = (key: string) => (raw: string) =>
+      signature.unsign(raw.slice(2), key);
+    const encodeFn = (key: string) => (sessId: string) =>
+      sessId && `s:${signature.sign(sessId, key)}`;
     const server = setUpServer(
       async (req, res) => {
         if (req.method === 'POST') req.session.hello = 'world';
@@ -147,7 +153,7 @@ describe('applySession', () => {
       {
         store,
         decode: decodeFn(secret),
-        encode: encodeFn(secret)
+        encode: encodeFn(secret),
       }
     );
     const server2 = setUpServer(
@@ -155,15 +161,21 @@ describe('applySession', () => {
       {
         store,
         decode: decodeFn(badSecret),
-        encode: encodeFn(badSecret)
+        encode: encodeFn(badSecret),
       }
-    )
+    );
     let sessId = '';
-    await request(server).post('/').expect('world').expect(({ header }) => {
-      sessId = parseCookie(header['set-cookie'][0]).sid;
-    })
+    await request(server)
+      .post('/')
+      .expect('world')
+      .expect(({ header }) => {
+        sessId = parseCookie(header['set-cookie'][0]).sid;
+      });
     // Return undefined due to mismatched secret
-    await request(server2).get('/').set('Cookie', `sid=${sessId}`).expect('undefined');
+    await request(server2)
+      .get('/')
+      .set('Cookie', `sid=${sessId}`)
+      .expect('undefined');
   });
 });
 
@@ -176,31 +188,33 @@ describe('withSession', () => {
     function handler(req: any, res: any) {
       return req.session;
     }
-    expect(await (withSession(handler) as NextApiHandler)(request, response)).toBeInstanceOf(
-      Session
-    );
+    expect(
+      await (withSession(handler) as NextApiHandler)(request, response)
+    ).toBeInstanceOf(Session);
   });
 
   test('works with pages#getInitialProps', async () => {
     const Page: NextPage = () => {
       return React.createElement('div');
-    }
+    };
     Page.getInitialProps = (context) => {
       return (context.req as IncomingMessage).session;
     };
     const ctx = { req: { headers: { cookie: '' } }, res: {} };
-    expect(await ((withSession(Page) as NextPage).getInitialProps as NonNullable<
-    NextComponentType['getInitialProps']
-  >)(ctx as any)).toBeInstanceOf(
-      Session
-    );
+    expect(
+      await ((withSession(Page) as NextPage).getInitialProps as NonNullable<
+        NextComponentType['getInitialProps']
+      >)(ctx as any)
+    ).toBeInstanceOf(Session);
   });
 
   test('return no-op if no ssr', async () => {
     function StaticPage() {
       return React.createElement('div');
     }
-    expect((withSession(StaticPage) as NextPage).getInitialProps).toBeUndefined();
+    expect(
+      (withSession(StaticPage) as NextPage).getInitialProps
+    ).toBeUndefined();
   });
 });
 
@@ -274,15 +288,26 @@ describe('promisifyStore', () => {
         cb && cb(null, this.sessions);
       }
 
-      set(sid: string, sess: SessionData, cb: (err: any, session?: SessionData | null) => void) {
+      set(
+        sid: string,
+        sess: SessionData,
+        cb: (err: any, session?: SessionData | null) => void
+      ) {
         cb && cb(null, this.sessions);
       }
 
-      destroy(sid: string, cb: (err: any, session?: SessionData | null) => void) {
+      destroy(
+        sid: string,
+        cb: (err: any, session?: SessionData | null) => void
+      ) {
         cb && cb(null, this.sessions);
       }
 
-      touch(sid: string, sess: SessionData, cb: (err: any, session?: SessionData | null) => void) {
+      touch(
+        sid: string,
+        sess: SessionData,
+        cb: (err: any, session?: SessionData | null) => void
+      ) {
         cb && cb(null, this.sessions);
       }
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,10 +9,10 @@ import {
   promisifyStore,
   withSession,
   session,
-  Options,
   SessionData,
   expressSession,
 } from '../src';
+import { Options } from '../src/types';
 import MemoryStore from '../src/store/memory';
 import Session from '../src/session';
 import Cookie from '../src/cookie';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -177,6 +177,16 @@ describe('applySession', () => {
       .set('Cookie', `sid=${sessId}`)
       .expect('undefined');
   });
+  test('should define session.isNew that determines if session is new', async () => {
+    const server = setUpServer((req, res) => {
+      const isNew = req.session.isNew;
+      req.session.foo = 'bar';
+      res.end(String(isNew));
+    });
+    const agent = request.agent(server);
+    await agent.get('/').expect('true');
+    await agent.get('/').expect('false');
+  })
 });
 
 describe('withSession', () => {


### PR DESCRIPTION
This PR applies several changes to avoid mutating `req`. Remove `req._sessId`, `req._sessOpts`, and `req._sessStr`.

We also remove some useless import.