### PR TITLE
fix(ts): inline extended request

### DIFF
--- a/src/extendedRequest.d.ts
+++ b/src/extendedRequest.d.ts
@@ -1,9 +1,0 @@
-import { Session, SessionStore, SessionOptions } from '.';
-
-declare module 'http' {
-  export interface IncomingMessage {
-    sessionId: string | null;
-    session: Session;
-    sessionStore: SessionStore;
-  }
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,13 @@
-/// <reference path="./extendedRequest.d.ts" />
-import { IncomingMessage, ServerResponse } from 'http';
+import type Session from "./session";
+import { IncomingMessage, ServerResponse } from "http";
+
+declare module "http" {
+  export interface IncomingMessage {
+    sessionId: string | null;
+    session: Session;
+    sessionStore: SessionStore;
+  }
+}
 
 export type SessionData = {
   [key: string]: any;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,3 @@
-/// <reference path="../src/extendedRequest.d.ts" />
 import React from 'react';
 import { createServer, RequestListener } from 'http';
 import request from 'supertest';


### PR DESCRIPTION
Hi!

This PR solves usage of `req.session` in typescript by in-lining `extendedRequests`, see my comment in #206 