### PR TITLE
Avoid calling session.commit more than once

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,12 +227,14 @@ if (loggedOut) req.session.destroy();
 
 ### req.session.commit()
 
-Save the session and set neccessary headers and return Promise. Use this if `autoCommit` is set to `false`. It must be called before sending response.
+Save the session and set neccessary headers. Return Promise. It must be called before *sending the headers (`res.writeHead`) or response (`res.send`, `res.end`, etc.)*.
+
+You **must** call this if `autoCommit` is set to `false`.
 
 ```javascript
 req.session.hello = 'world';
 await req.session.commit();
-// calling res.end or finishing the resolver after the above
+// always calling res.end or res.writeHead after the above
 ```
 
 ### req.session.id

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,6 +14,7 @@ declare interface Session {
   res: Response;
   _opts: SessionOptions;
   _sessStr: string;
+  _committed: boolean;
   isNew: boolean;
 }
 
@@ -30,6 +31,7 @@ class Session {
       req: { value: req },
       res: { value: res },
       _opts: { value: options },
+      _committed: { value: false, writable: true },
       isNew: { value: false, writable: true }
     });
     if (sess) {
@@ -70,6 +72,8 @@ class Session {
   }
 
   async commit() {
+    if (this._committed) return;
+    this._committed = true;
     const { name, rolling, touchAfter } = this._opts;
     let touched = false;
     let saved = false;


### PR DESCRIPTION
This is helpful when `autoCommit = true`, but we still want to call `session.commit()` anyway.