### PR TITLE
Fix autoCommit usage with res.writeHead

### DIFF
--- a/src/compat.ts
+++ b/src/compat.ts
@@ -34,6 +34,6 @@ export function promisifyStore(
   store.get = promisify(store.get);
   store.set = promisify(store.set);
   store.destroy = promisify(store.destroy);
-  if (typeof store.touch === 'function') store.touch = promisify(store.touch);
+  if (store.touch) store.touch = promisify(store.touch);
   return store as SessionStore;
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -33,7 +33,7 @@ export async function applySession<T = {}>(
     : null;
 
   if (sessId && typeof options.decode === 'function') {
-    sessId = await options.decode(sessId);
+    sessId = options.decode(sessId);
   }
 
   (req as any).sessionStore = options.store;
@@ -45,10 +45,15 @@ export async function applySession<T = {}>(
 
   // autocommit
   if (options.autoCommit) {
+    const oldWritehead = res.writeHead;
+    res.writeHead = function resWriteHeadProxy(...args: any) {
+      if (!(res.finished || res.writableEnded))
+        req.session.commitHead();
+      return oldWritehead.apply(this, args);
+    }
     const oldEnd = res.end;
     res.end = async function resEndProxy(...args: any) {
-      if (res.finished || res.writableEnded) return;
-      if (req.session) await req.session.commit();
+      await req.session.save();
       oldEnd.apply(this, args);
     };
   }

--- a/src/core.ts
+++ b/src/core.ts
@@ -32,7 +32,7 @@ export async function applySession<T = {}>(
     ? parseCookie(req.headers.cookie)[options.name]
     : null;
 
-  if (sessId && typeof options.decode === 'function') {
+  if (sessId && options.decode) {
     sessId = options.decode(sessId);
   }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -47,8 +47,7 @@ export async function applySession<T = {}>(
   if (options.autoCommit) {
     const oldWritehead = res.writeHead;
     res.writeHead = function resWriteHeadProxy(...args: any) {
-      if (!(res.finished || res.writableEnded))
-        req.session.commitHead();
+      req.session.commitHead();
       return oldWritehead.apply(this, args);
     }
     const oldEnd = res.end;

--- a/src/session.ts
+++ b/src/session.ts
@@ -43,7 +43,7 @@ class Session<T = {}> {
   touch() {
     this.cookie.resetExpires();
     //  check if store supports touch()
-    if (typeof this._opts.store.touch === 'function') {
+    if (this._opts.store.touch) {
       return this._opts.store.touch(this.id, this);
     }
     return Promise.resolve();
@@ -87,7 +87,7 @@ class Session<T = {}> {
         'Set-Cookie',
         this.cookie.serialize(
           this._opts.name,
-          typeof this._opts.encode === 'function'
+          this._opts.encode
             ? this._opts.encode(this.id)
             : this.id
         )

--- a/src/session.ts
+++ b/src/session.ts
@@ -79,9 +79,10 @@ class Session<T = {}> {
   }
 
   commitHead() {
+    // Header sent, cannot commit
+    if (this.res.headersSent) return;
     // Check if new cookie should be set
     if ((this._opts.rolling && this.shouldTouch()) || this.isNew) {
-      if (this.res.headersSent) return;
       this.res.setHeader(
         'Set-Cookie',
         this.cookie.serialize(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -197,6 +197,16 @@ describe('applySession', () => {
     await agent.get('/').expect('true');
     await agent.get('/').expect('false');
   })
+
+  test('should works with writeHead and autoCommit', async () => {
+    const server = setUpServer((req, res) => {
+      req.session.foo = 'bar';
+      res.writeHead(302, { Location: '/login' }).end()
+    });
+    await request(server)
+      .post('/')
+      .then(({ header }) => expect(header).toHaveProperty('set-cookie'));
+  })
 });
 
 describe('withSession', () => {


### PR DESCRIPTION
Hopefully fix #236. 

This hook our `setHead` (set cookie header) function to `writeHead`. However, we are forced to remove async function support for `encode/decode`.