### PR TITLE
Fix callback store support

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,8 +200,6 @@ session({
   decode: (raw) => signature.unsign(raw.slice(2), secret),
   encode: (sid) => (sid ? 's:' + signature.sign(sid, secret) : null),
 });
-
-// async function is also supported
 ```
 
 ## API
@@ -266,6 +264,18 @@ const MongoStore = require('connect-mongo')(expressSession);
 ### Implementation
 
 A compatible session store must include three functions: `set(sid, session)`, `get(sid)`, and `destroy(sid)`. The function `touch(sid, session)` is recommended. All functions can either return **Promises** or allowing **callback** in the last argument.
+
+```js
+// Both of the below work!
+
+function get(sid) {
+  return promiseGetFn(sid)
+}
+
+function get(sid, done) {
+  cbGetFn(sid, done);
+}
+```
 
 ## Contributing
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -69,7 +69,7 @@ function setupStore(store: SessionStore | ExpressStore | NormalizedSessionStore)
   s.__destroy = function destroy(sid) {
     return new Promise((resolve, reject) => {
       const done = (err: any) => err ? reject(err) : resolve()
-      const result = store.destroy(sid, done);
+      const result = this.destroy(sid, done);
       if (result && typeof result.then === 'function') result.then(resolve, reject);
     })
   }
@@ -77,7 +77,7 @@ function setupStore(store: SessionStore | ExpressStore | NormalizedSessionStore)
   s.__get = function get(sid) {
     return new Promise((resolve, reject) => {
       const done = (err: any, val: SessionData) => err ? reject(err) : resolve(val)
-      const result = store.destroy(sid, done);
+      const result = this.get(sid, done);
       if (result && typeof result.then === 'function') result.then(resolve, reject);
     })
   }
@@ -85,7 +85,7 @@ function setupStore(store: SessionStore | ExpressStore | NormalizedSessionStore)
   s.__set = function set(sid, sess) {
     return new Promise((resolve, reject) => {
       const done = (err: any) => err ? reject(err) : resolve();
-      const result = store.set(sid, sess, done);
+      const result = this.set(sid, sess, done);
       if (result && typeof result.then === 'function') result.then(resolve, reject);
     })
   }
@@ -94,7 +94,7 @@ function setupStore(store: SessionStore | ExpressStore | NormalizedSessionStore)
     s.__touch = function touch(sid, sess) {
       return new Promise((resolve, reject) => {
         const done = (err: any) => err ? reject(err) : resolve();
-        const result = store.touch(sid, sess, done);
+        const result = this.touch(sid, sess, done);
         if (result && typeof result.then === 'function') result.then(resolve, reject);
       })
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -351,15 +351,21 @@ describe('callback store', () => {
   it('should work', async () => {
     const server = setUpServer(defaultHandler, {
       store: (new CbStore() as unknown) as ExpressStore,
+      rolling: true
     });
     const agent = request.agent(server);
     await agent
       .post('/')
       .then(({ header }) => expect(header).toHaveProperty('set-cookie'));
     await agent
-      .get('/')
-      .expect('1')
+      .post('/')
       .then(({ header }) => expect(header).not.toHaveProperty('set-cookie'));
+    await agent.get('/').expect('2');
+    await agent.delete('/');
+    await await agent
+      .post('/')
+      .expect('1')
+      .then(({ header }) => expect(header).toHaveProperty('set-cookie'));
   });
 });
 


### PR DESCRIPTION
Using `function.get` is unreliable if the store function contains optional param.

This rewrite creates a real `__fn` functions that will process promise/cb handling during runtime.

Ex.

```js
s.__get = function get(sid) {
    return new Promise((resolve, reject) => {
      const done = (err: any, val: SessionData) => err ? reject(err) : resolve(val)
      const result = this.get(sid, done);
      if (result && typeof result.then === 'function') result.then(resolve, reject);
    })
  }
```

Also contains a small change to use `Symbol` to store session working states