### PR TITLE
Refactor, remove rolling option and fix unreliable tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,7 @@ await applySession(req, res, options);
 | genid | The function that generates a string for a new session ID. | [`nanoid`](https://github.com/ai/nanoid) |
 | encode | Transforms session ID before setting cookie. It takes the raw session ID and returns the decoded/decrypted session ID. | undefined |
 | decode | Transforms session ID back while getting from cookie. It should return the encoded/encrypted session ID | undefined |
-| touchAfter | Only touch (extend session lifetime despite no modification) after an amount of time to decrease database load. Setting the value to `-1` will disable `touch()`. | `0` (Touch every time) |
-| rolling | Extends the life time of the cookie in the browser if the session is touched. This respects touchAfter. | `false` |
+| touchAfter | Only touch (extend session lifetime, both in browser and store, despite no modification) after an amount of time to decrease database load. Setting the value to `-1` will disable `touch`. | `0` (Touch every time) |
 | autoCommit | Automatically commit session. Disable this if you want to manually `session.commit()` | `true` |
 | cookie.secure | Specifies the boolean value for the **Secure** `Set-Cookie` attribute. | `false` |
 | cookie.httpOnly | Specifies the boolean value for the **httpOnly** `Set-Cookie` attribute. | `true` |

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ await applySession(req, res, options);
 | genid | The function that generates a string for a new session ID. | [`nanoid`](https://github.com/ai/nanoid) |
 | encode | Transforms session ID before setting cookie. It takes the raw session ID and returns the decoded/decrypted session ID. | undefined |
 | decode | Transforms session ID back while getting from cookie. It should return the encoded/encrypted session ID | undefined |
-| touchAfter | Only touch (extend session lifetime, both in browser and store, despite no modification) after an amount of time. Setting the value to `-1` will disable `touch`. | `0` (Touch every time) |
+| touchAfter | Only touch after an amount of time. Disabled by default or if set to `-1`. See [touchAfter](#touchAfter). | `-1` (Disabled) |
 | autoCommit | Automatically commit session. Disable this if you want to manually `session.commit()` | `true` |
 | cookie.secure | Specifies the boolean value for the **Secure** `Set-Cookie` attribute. | `false` |
 | cookie.httpOnly | Specifies the boolean value for the **httpOnly** `Set-Cookie` attribute. | `true` |
@@ -188,6 +188,12 @@ await applySession(req, res, options);
 | cookie.domain | Specifies the value for the **Domain** `Set-Cookie` attribute. | unset |
 | cookie.sameSite | Specifies the value for the **SameSite** `Set-Cookie` attribute. | unset |
 | cookie.maxAge | **(in seconds)** Specifies the value for the **Max-Age** `Set-Cookie` attribute. | unset (Browser session) |
+
+### touchAfter
+
+Touching refers to the extension of session lifetime, both in browser (by modifying `Expires` attribute in [Set-Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie) header) and session store (using its respective method). This prevents the session from being expired after a while.
+
+In `autoCommit` mode (which is enabled by default), for optimization, a session is only touched, not saved, if it is not modified. The value of `touchAfter` allows you to skip touching if the session is still recent, thus, decreasing database load.
 
 ### encode/decode
 

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -28,6 +28,6 @@ expressSession.MemoryStore = CallbackMemoryStore;
 export { expressSession };
 
 export function promisifyStore(store: ExpressStore): ExpressStore {
-  console.warn('promisifyStore has been deprecated! You can simply remove it.');
+  console.warn('promisifyStore has been deprecated: express-session store still works without using this.');
   return store;
 }

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -8,8 +8,8 @@ export function Store() {
   EventEmitter.call(this);
 }
 inherits(Store, EventEmitter);
-// no-op for compat
 
+// no-op for compat
 function expressSession(options?: any): any {}
 
 expressSession.Store = Store;
@@ -28,6 +28,8 @@ expressSession.MemoryStore = CallbackMemoryStore;
 export { expressSession };
 
 export function promisifyStore(store: ExpressStore): ExpressStore {
-  console.warn('promisifyStore has been deprecated: express-session store still works without using this.');
+  console.warn(
+    'promisifyStore has been deprecated: express-session store still works without using this.'
+  );
   return store;
 }

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -1,5 +1,5 @@
 import { applySession } from './core';
-import { Options, SessionData } from './types';
+import { Options } from './types';
 import { IncomingMessage, ServerResponse } from 'http';
 
 let storeReady = true;
@@ -15,7 +15,7 @@ export default function session(opts?: Options) {
     });
   }
   return (
-    req: IncomingMessage & { session?: SessionData },
+    req: IncomingMessage,
     res: ServerResponse,
     next: (err?: any) => void
   ) => {

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -15,7 +15,7 @@ export default function session(opts?: Options) {
     });
   }
   return (
-    req: IncomingMessage & { session: SessionData },
+    req: IncomingMessage & { session?: SessionData },
     res: ServerResponse,
     next: (err?: any) => void
   ) => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -138,11 +138,9 @@ export async function applySession<T = {}>(
       typeof opts?.autoCommit !== 'undefined' ? opts.autoCommit : true,
   };
 
-  if (opts?.rolling) {
-    console.warn("The use of opts.rolling is deprecated. Setting this to `true` without opts.touchAfter will cause opts.touchAfter to become 0 (always)");
-    if (typeof opts.touchAfter === 'undefined') {
-      options.touchAfter = 0;
-    }
+  if (opts?.rolling && !('touchAfter' in opts)) {
+    console.warn("The use of opts.rolling is deprecated. Setting this to `true` without opts.touchAfter causes opts.touchAfter to be defaulted to `0` (always)");
+    options.touchAfter = 0;
   }
 
   let sessId =

--- a/src/core.ts
+++ b/src/core.ts
@@ -142,7 +142,7 @@ export async function applySession<T = {}>(
     genid: opts?.genid || nanoid,
     encode: opts?.encode,
     decode: opts?.decode,
-    touchAfter: opts?.touchAfter ? opts.touchAfter : 0,
+    touchAfter: opts?.touchAfter ? opts.touchAfter : -1,
     autoCommit:
       typeof opts?.autoCommit !== 'undefined' ? opts.autoCommit : true,
   };
@@ -163,8 +163,7 @@ export async function applySession<T = {}>(
 
   const destroy = async () => {
     await options.store.__destroy(req.session.id);
-    // This is a valid TS error, but considering its usage, it's fine.
-    // @ts-ignore
+    // @ts-ignore: This is a valid TS error, but considering its usage, it's fine.
     delete req.session;
   };
 
@@ -206,7 +205,7 @@ export async function applySession<T = {}>(
     ((req as any)[SESS_TOUCHED] = shouldTouch(
       req.session.cookie,
       options.touchAfter
-    ))
+    )) || req.session.isNew
   ) {
     req.session.cookie.expires = new Date(
       Date.now() + req.session.cookie.maxAge! * 1000

--- a/src/core.ts
+++ b/src/core.ts
@@ -7,13 +7,12 @@ import {
   Options,
   SessionData,
   SessionStore,
-  SessionCookieData,
   NormalizedSessionStore,
 } from './types';
 
 type SessionOptions = Omit<
   Required<Options>,
-  'encode' | 'decode' | 'store' | 'cookie'
+  'encode' | 'decode' | 'store' | 'cookie' | 'rolling'
 > &
   Pick<Options, 'encode' | 'decode'> & {
     store: NormalizedSessionStore;
@@ -138,6 +137,13 @@ export async function applySession<T = {}>(
     autoCommit:
       typeof opts?.autoCommit !== 'undefined' ? opts.autoCommit : true,
   };
+
+  if (opts?.rolling) {
+    console.warn("The use of opts.rolling is deprecated. Setting this to `true` without opts.touchAfter will cause opts.touchAfter to become 0 (always)");
+    if (typeof opts.touchAfter === 'undefined') {
+      options.touchAfter = 0;
+    }
+  }
 
   let sessId =
     req.headers && req.headers.cookie

--- a/src/core.ts
+++ b/src/core.ts
@@ -143,7 +143,10 @@ export async function applySession<T = {}>(
 
   // Even though req.session as this point is not of type Session
   // but SessionData, the missing keys will be added later
-  req.session = (sessId ? await store.__get(sessId) : null) as Session | null | undefined;
+  req.session = (sessId ? await store.__get(sessId) : null) as
+    | Session
+    | null
+    | undefined;
 
   if (req.session) {
     req.session.commit = commit;

--- a/src/core.ts
+++ b/src/core.ts
@@ -171,6 +171,7 @@ export async function applySession<T = {}>(
   if (sess) {
     (req as any)[SESS_PREV] = stringify(sess);
     const { cookie, ...data } = sess;
+    // Some store return cookie.expires as string, convert it to Date
     if (typeof cookie.expires === 'string')
       cookie.expires = new Date(cookie.expires);
     req.session = {

--- a/src/core.ts
+++ b/src/core.ts
@@ -41,7 +41,7 @@ const commitHead = (
   options: SessionOptions
 ) => {
   if (res.headersSent || !req.session) return;
-  if (req.session.isNew || (options.rolling && (req as any)[SESS_TOUCHED])) {
+  if (req.session.isNew || (req as any)[SESS_TOUCHED]) {
     res.setHeader(
       'Set-Cookie',
       serialize(
@@ -69,7 +69,6 @@ const save = async (
   for (const key in req.session) {
     if (!(key === ('isNew' || key === 'id'))) obj[key] = req.session[key];
   }
-
   if (stringify(req.session) !== (req as any)[SESS_PREV]) {
     await options.store.__set(req.session.id, obj);
   } else if ((req as any)[SESS_TOUCHED]) {
@@ -143,7 +142,6 @@ export async function applySession<T = {}>(
     genid: opts?.genid || nanoid,
     encode: opts?.encode,
     decode: opts?.decode,
-    rolling: opts?.rolling || false,
     touchAfter: opts?.touchAfter ? opts.touchAfter : 0,
     autoCommit:
       typeof opts?.autoCommit !== 'undefined' ? opts.autoCommit : true,

--- a/src/core.ts
+++ b/src/core.ts
@@ -127,7 +127,7 @@ export async function applySession<T = {}>(
   const name = options.name || 'sid';
 
   const commit = async () => {
-    commitHead(res, name, req.session, shouldTouch ,options.encode);
+    commitHead(res, name, req.session, shouldTouch, options.encode);
     await save(store, req.session);
   };
 
@@ -142,7 +142,7 @@ export async function applySession<T = {}>(
 
   // @ts-ignore: req.session as this point is not of type Session
   // but SessionData, but the missing keys will be added later
-  req.session = (sessId ? await store.__get(sessId) : null);
+  req.session = sessId ? await store.__get(sessId) : null;
 
   if (req.session) {
     req.session.commit = commit;
@@ -182,7 +182,7 @@ export async function applySession<T = {}>(
         : stringify(req.session)
       : undefined;
 
-  let shouldTouch = false
+  let shouldTouch = false;
 
   if (req.session.cookie.maxAge) {
     if (

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -1,5 +1,6 @@
-import { EventEmitter } from "events";
-import { SessionStore, SessionData } from "../types";
+import { EventEmitter } from 'events';
+import { SessionStore, SessionData } from '../types';
+
 export default class MemoryStore extends EventEmitter implements SessionStore {
   public sessions: Record<string, string> = {};
 

--- a/src/store/memory.ts
+++ b/src/store/memory.ts
@@ -38,16 +38,7 @@ export default class MemoryStore extends EventEmitter implements SessionStore {
   }
 
   touch(sid: string, session: SessionData) {
-    return this.get(sid).then((sess) => {
-      if (sess) {
-        const newSess = {
-          ...sess,
-          cookie: session.cookie,
-        };
-        return this.set(sid, newSess);
-      }
-      return undefined;
-    });
+    return this.set(sid, session);
   }
 
   all() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,6 @@ export interface Options {
   genid?: () => string;
   encode?: (rawSid: string) => string;
   decode?: (encryptedSid: string) => string;
-  rolling?: boolean;
   touchAfter?: number;
   cookie?: CookieOptions;
   autoCommit?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,15 +8,13 @@ export type SessionData = {
   isNew: boolean;
 };
 
-export interface SessionCookieData {
+export type SessionCookieData = {
   path: string;
-  maxAge: number | null;
   secure: boolean;
   httpOnly: boolean;
   domain?: string | undefined;
-  expires?: Date;
   sameSite?: boolean | 'lax' | 'strict' | 'none';
-}
+} & ({ maxAge: number, expires: Date } | { maxAge: null, expires?: undefined })
 
 export abstract class SessionStore {
   abstract get: (sid: string) => Promise<SessionData | null>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,4 +51,8 @@ export interface Options {
   touchAfter?: number;
   cookie?: CookieOptions;
   autoCommit?: boolean;
+  /**
+   * @deprecated
+   */
+  rolling?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,12 +2,15 @@ import { Store as ExpressStore } from 'express-session';
 
 export type SessionData = {
   [key: string]: any;
-  id: string;
   cookie: SessionCookieData;
-  commit: () => Promise<void>;
-  destroy: () => Promise<void>;
-  isNew: boolean;
 };
+
+export interface Session extends SessionData {
+  id: string;
+  commit(): Promise<void>;
+  destroy(): Promise<void>;
+  isNew: boolean;
+}
 
 export type SessionCookieData = {
   path: string;
@@ -15,33 +18,23 @@ export type SessionCookieData = {
   httpOnly: boolean;
   domain?: string | undefined;
   sameSite?: boolean | 'lax' | 'strict' | 'none';
-} & ({ maxAge: number, expires: Date } | { maxAge: null, expires?: undefined })
+} & ({ maxAge: number; expires: Date } | { maxAge: null; expires?: undefined });
 
 export abstract class SessionStore {
-  abstract get: (sid: string) => Promise<SessionData | null>;
-  abstract set: (sid: string, sess: SessionData) => Promise<void>;
-  abstract destroy: (sid: string) => Promise<void>;
-  abstract touch?: (sid: string, sess: SessionData) => Promise<void>;
-  on?: (event: string | symbol, listener: (...args: any[]) => void) => this;
+  abstract get(sid: string): Promise<SessionData | null | undefined>;
+  abstract set(sid: string, sess: SessionData): Promise<void>;
+  abstract destroy(sid: string): Promise<void>;
+  abstract touch?(sid: string, sess: SessionData): Promise<void>;
+  on?(event: string | symbol, listener: (...args: any[]) => void): this;
 }
 
-export interface NormalizedSessionStore {
-  [key: string]: any;
-  __get: (sid: string) => Promise<SessionData | null>;
-  __set: (sid: string, sess: SessionData) => Promise<void>;
-  __destroy: (sid: string) => Promise<void>;
-  __touch?: (sid: string, sess: SessionData) => Promise<void>;
-  __normalized: true,
-}
-
-export interface CookieOptions {
-  secure?: boolean;
-  httpOnly?: boolean;
-  path?: string;
-  domain?: string;
-  sameSite?: boolean | 'lax' | 'strict' | 'none';
-  maxAge?: number | null;
-}
+export type NormalizedSessionStore = {
+  __get(sid: string): Promise<SessionData | null | undefined>;
+  __set(sid: string, sess: SessionData): Promise<void>;
+  __destroy(sid: string): Promise<void>;
+  __touch(sid: string, sess: SessionData): Promise<void>;
+  __normalized: true;
+} & (SessionStore | ExpressStore)
 
 export interface Options {
   name?: string;
@@ -50,7 +43,14 @@ export interface Options {
   encode?: (rawSid: string) => string;
   decode?: (encryptedSid: string) => string | null;
   touchAfter?: number;
-  cookie?: CookieOptions;
+  cookie?: {
+    secure?: boolean;
+    httpOnly?: boolean;
+    path?: string;
+    domain?: string;
+    sameSite?: boolean | 'lax' | 'strict' | 'none';
+    maxAge?: number | null;
+  };
   autoCommit?: boolean;
   /**
    * @deprecated

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type NormalizedSessionStore = {
   __destroy(sid: string): Promise<void>;
   __touch(sid: string, sess: SessionData): Promise<void>;
   __normalized: true;
-} & (SessionStore | ExpressStore)
+} & (SessionStore | ExpressStore);
 
 export interface Options {
   name?: string;

--- a/src/withSession.ts
+++ b/src/withSession.ts
@@ -9,7 +9,7 @@ import {
 } from 'next';
 
 import { applySession } from './core';
-import { Options, SessionData } from './types';
+import { Options } from './types';
 
 function getDisplayName(WrappedComponent: NextComponentType<any>) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';
@@ -31,11 +31,7 @@ export default function withSession<T = {}>(
       req: NextApiRequest,
       res: NextApiResponse
     ) {
-      await applySession(
-        req as NextApiRequest & { session: SessionData },
-        res,
-        options
-      );
+      await applySession(req, res, options);
       return handler(req, res);
     };
 
@@ -49,17 +45,9 @@ export default function withSession<T = {}>(
     WithSession.getInitialProps = async (pageCtx: NextPageContext) => {
       // @ts-ignore
       if (typeof window === 'undefined') {
-        await applySession(
-          pageCtx.req as NonNullable<NextPageContext['req']> & {
-            session: SessionData;
-          },
-          pageCtx.res as NonNullable<NextPageContext['res']>,
-          options
-        );
+        await applySession(pageCtx.req!, pageCtx.res!, options);
       }
-      return (Page.getInitialProps as NonNullable<
-        NextComponentType['getInitialProps']
-      >)(pageCtx);
+      return Page.getInitialProps!(pageCtx);
     };
   }
   return WithSession;

--- a/src/withSession.ts
+++ b/src/withSession.ts
@@ -3,11 +3,8 @@ import {
   NextPage,
   NextPageContext,
   NextApiHandler,
-  NextApiRequest,
-  NextApiResponse,
   NextComponentType,
 } from 'next';
-
 import { applySession } from './core';
 import { Options } from './types';
 
@@ -27,13 +24,10 @@ export default function withSession<T = {}>(
 ): NextApiHandler | NextPage {
   // API Routes
   if (isNextApiHandler(handler))
-    return async function WithSession(
-      req: NextApiRequest,
-      res: NextApiResponse
-    ) {
+    return async function WithSession(req, res) {
       await applySession(req, res, options);
       return handler(req, res);
-    };
+    } as NextApiHandler;
 
   // Pages
   const Page = handler;

--- a/src/withSession.ts
+++ b/src/withSession.ts
@@ -43,7 +43,6 @@ export default function withSession<T = {}>(
   WithSession.displayName = `withSession(${getDisplayName(Page)})`;
   if (Page.getInitialProps) {
     WithSession.getInitialProps = async (pageCtx: NextPageContext) => {
-      // @ts-ignore
       if (typeof window === 'undefined') {
         await applySession(pageCtx.req!, pageCtx.res!, options);
       }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -421,7 +421,7 @@ describe('Store', () => {
 describe('callback store', () => {
   it('should work', async () => {
     const server = setUpServer(defaultHandler, {
-      store: (new CbStore() as unknown) as ExpressStore
+      store: (new CbStore() as unknown) as ExpressStore,
     });
     const agent = request.agent(server);
     await agent
@@ -437,6 +437,21 @@ describe('callback store', () => {
       .expect('1')
       .then(({ header }) => expect(header).toHaveProperty('set-cookie'));
   });
+  it('should work (with touch)', async () => {
+    const server = setUpServer(defaultHandler, {
+      store: (new CbStore() as unknown) as ExpressStore,
+      cookie: { maxAge: 100 },
+      touchAfter: 0,
+    });
+    const agent = request.agent(server);
+    await agent
+      .post('/')
+      .then(({ header }) => expect(header).toHaveProperty('set-cookie'));
+    await agent
+      .post('/')
+      .then(({ header }) => expect(header).toHaveProperty('set-cookie'));
+    await agent.get('/').expect('2');
+  })
   it('should work (without touch)', async () => {
     const store = (new CbStore() as unknown) as ExpressStore;
     delete store.touch;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -141,7 +141,7 @@ describe('applySession', () => {
       .then(({ header }) => expect(header).toHaveProperty('set-cookie'));
   });
 
-  test('should always touch by default', async () => {
+  test('should not touch by default', async () => {
     const server = setUpServer(
       (req, res) => {
         req.session.hello = 'world';
@@ -153,14 +153,12 @@ describe('applySession', () => {
       }
     );
     const agent = request.agent(server);
-    await agent.post('/');
-    let originalExpires;
-    await agent.get('/').then((res) => {
-      originalExpires = res.text;
-    });
-    const res = await agent.get('/');
-    expect(res.text).not.toStrictEqual(originalExpires);
+    const res = (await agent.get('/'))
+    const originalExpires = res.text;
     expect(res.header).toHaveProperty('set-cookie');
+    const res2 = await agent.get('/');
+    expect(res2.text).toStrictEqual(originalExpires);
+    expect(res2.header).not.toHaveProperty('set-cookie');
   });
 
   test('should touch if lifetime > touchAfter', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import React from 'react';
 import { createServer, RequestListener } from 'http';
 import request from 'supertest';
@@ -40,12 +41,6 @@ class CbStore {
 
   touch(sid: string, sess: SessionData, cb: (err: any) => void) {
     cb && cb(null);
-  }
-}
-
-declare module 'http' {
-  export interface IncomingMessage {
-    session: SessionData;
   }
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -437,6 +437,25 @@ describe('callback store', () => {
       .expect('1')
       .then(({ header }) => expect(header).toHaveProperty('set-cookie'));
   });
+  it('should work (without touch)', async () => {
+    const store = (new CbStore() as unknown) as ExpressStore;
+    delete store.touch;
+    const server = setUpServer(defaultHandler, { store });
+    expect(store).not.toHaveProperty('__touch');
+    const agent = request.agent(server);
+    await agent
+      .post('/')
+      .then(({ header }) => expect(header).toHaveProperty('set-cookie'));
+    await agent
+      .post('/')
+      .then(({ header }) => expect(header).not.toHaveProperty('set-cookie'));
+    await agent.get('/').expect('2');
+    await agent.delete('/');
+    await await agent
+      .post('/')
+      .expect('1')
+      .then(({ header }) => expect(header).toHaveProperty('set-cookie'));
+  });
 });
 
 describe('promisifyStore', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -143,7 +143,6 @@ describe('applySession', () => {
         res.end(`${req.session.cookie.expires?.valueOf()}`);
       },
       {
-        rolling: true,
         touchAfter: 5000,
         cookie: { maxAge: 60 * 60 * 24 },
         store: new MemoryStore(),
@@ -157,7 +156,6 @@ describe('applySession', () => {
     });
     const res = await agent.get('/');
     expect(res.text).toStrictEqual(originalExpires);
-    // should not set-cookie despite rolling=true
     expect(res.header).not.toHaveProperty('set-cookie');
   });
 
@@ -350,8 +348,7 @@ describe('Store', () => {
 describe('callback store', () => {
   it('should work', async () => {
     const server = setUpServer(defaultHandler, {
-      store: (new CbStore() as unknown) as ExpressStore,
-      rolling: true
+      store: (new CbStore() as unknown) as ExpressStore
     });
     const agent = request.agent(server);
     await agent

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -63,18 +63,23 @@ function setUpServer(
 ) {
   const server = createServer(async (req: IncomingMessage, res) => {
     if (prehandler) await prehandler(req, res);
-    if (options !== false) await applySession(req as any, res, options);
+    if (options !== false) {
+      await applySession(req as any, res, options);
+    }
     await handler(req, res);
   });
   return server;
 }
 
 describe('applySession', () => {
-  test('should default to MemoryStore', async () => {
+  test('should default to MemoryStore that attaches to global', async () => {
     const req: any = {};
     const res: any = { end: () => null };
     await applySession(req, res);
     expect(req.sessionStore).toBeInstanceOf(MemoryStore);
+    const req2: any = {};
+    await applySession(req2, res);
+    expect(req2.sessionStore).toBe(req.sessionStore)
   });
 
   test('should do nothing if req.session is defined', async () => {
@@ -87,7 +92,7 @@ describe('applySession', () => {
   });
 
   test('should create and persist session', async () => {
-    const server = setUpServer(defaultHandler);
+    const server = setUpServer(defaultHandler, { store: new MemoryStore() });
     const agent = request.agent(server);
     await agent
       .post('/')
@@ -125,7 +130,7 @@ describe('applySession', () => {
         if (req.method === 'POST') await req.session.commit();
         res.end((req.session && req.session.hello) || '');
       },
-      { autoCommit: false }
+      { autoCommit: false, store: new MemoryStore() }
     );
     const agent = request.agent(server);
     await agent
@@ -136,14 +141,69 @@ describe('applySession', () => {
       .then(({ header }) => expect(header).toHaveProperty('set-cookie'));
   });
 
-  test('should respect touchAfter', async () => {
+  test('should always touch by default', async () => {
     const server = setUpServer(
       (req, res) => {
         req.session.hello = 'world';
         res.end(`${req.session.cookie.expires?.valueOf()}`);
       },
       {
-        touchAfter: 5000,
+        cookie: { maxAge: 60 * 60 * 24 },
+        store: new MemoryStore(),
+      }
+    );
+    const agent = request.agent(server);
+    await agent.post('/');
+    let originalExpires;
+    await agent.get('/').then((res) => {
+      originalExpires = res.text;
+    });
+    const res = await agent.get('/');
+    expect(res.text).not.toStrictEqual(originalExpires);
+    expect(res.header).toHaveProperty('set-cookie');
+  });
+
+  test('should touch if lifetime > touchAfter', async () => {
+    const sessionStore = new MemoryStore();
+    let sessId: string = ''
+    const server = setUpServer(
+      (req, res) => {
+        req.session.hello = 'world';
+        sessId = req.session.id;
+        res.end(`${req.session.cookie.expires?.valueOf()}`);
+      },
+      {
+        touchAfter: 8 * 1000, // 8 sec
+        cookie: { maxAge: 60 * 60 * 24 },
+        store: sessionStore,
+      }
+    );
+    const agent = request.agent(server);
+    await agent.post('/');
+    let originalExpires;
+    await agent.get('/').then((res) => {
+      originalExpires = res.text;
+    });
+
+    //  Shift expires 10 seconds to simulate 10 seconds time fly
+    const sess = await sessionStore.get(sessId as string);
+    // Force 10 sec back in the past for cookie to expire
+    sess!.cookie.expires! = new Date(sess!.cookie.expires!.valueOf() - 10 * 1000)
+    await sessionStore.set(sessId as string, sess!)
+
+    const res = await agent.get('/');
+    expect(res.text).not.toStrictEqual(originalExpires);
+    expect(res.header).toHaveProperty('set-cookie');
+  })
+
+  test('should not touch if lifetime < touchAfter', async () => {
+    const server = setUpServer(
+      (req, res) => {
+        req.session.hello = 'world';
+        res.end(`${req.session.cookie.expires?.valueOf()}`);
+      },
+      {
+        touchAfter: 20 * 1000,
         cookie: { maxAge: 60 * 60 * 24 },
         store: new MemoryStore(),
       }
@@ -215,7 +275,7 @@ describe('applySession', () => {
       const isNew = req.session.isNew;
       req.session.foo = 'bar';
       res.end(String(isNew));
-    });
+    }, {store: new MemoryStore()});
     const agent = request.agent(server);
     await agent.get('/').expect('true');
     await agent.get('/').expect('false');
@@ -225,10 +285,35 @@ describe('applySession', () => {
     const server = setUpServer((req, res) => {
       req.session.foo = 'bar';
       res.writeHead(302, { Location: '/login' }).end();
-    });
+    }, {store: new MemoryStore()});
     await request(server)
       .post('/')
       .then(({ header }) => expect(header).toHaveProperty('set-cookie'));
+  });
+
+  test('should convert String() expires to Date() expires', async () => {
+    const sessions: Record<string, string> = {
+      //  force sess.cookie.expires to be string
+      test: JSON.stringify({
+        cookie: { maxAge: 100000, expires: new Date(Date.now() + 4000) },
+      }),
+    };
+
+    const store = {
+      get: async (id: string) => {
+        return JSON.parse(sessions[id]);
+      },
+      set: async (sid: string, sess: SessionData) => undefined,
+      destroy: async (id: string) => undefined,
+    };
+
+    const req = { headers: { cookie: 'sid=test' } } as any;
+    await applySession(req, { end: () => true, writeHead: () => true } as any, {
+      cookie: { maxAge: 5000 },
+      store,
+    });
+
+    expect(req.session.cookie.expires).toBeInstanceOf(Date);
   });
 });
 
@@ -302,32 +387,6 @@ describe('connect middleware', () => {
 });
 
 describe('Store', () => {
-  test('should convert String() expires to Date() expires', async () => {
-    // FIXME
-    const sessions: Record<string, string> = {
-      //  force sess.cookie.expires to be string
-      test: JSON.stringify({
-        cookie: { maxAge: 100000, expires: new Date(Date.now() + 4000) },
-      }),
-    };
-
-    const store = {
-      get: async (id: string) => {
-        return JSON.parse(sessions[id]);
-      },
-      set: async (sid: string, sess: SessionData) => undefined,
-      destroy: async (id: string) => undefined,
-    };
-
-    const req = { headers: { cookie: 'sid=test' } } as any;
-    await applySession(req, { end: () => true, writeHead: () => true } as any, {
-      cookie: { maxAge: 5000 },
-      store,
-    });
-
-    expect;
-    expect(req.session.cookie.expires).toBeInstanceOf(Date);
-  });
   test('should extend EventEmitter', () => {
     // @ts-ignore
     expect(new expressSession.Store()).toBeInstanceOf(EventEmitter);
@@ -415,9 +474,12 @@ describe('MemoryStore', () => {
     const agent = request.agent(server);
     await agent.post('/');
     await agent.get('/').expect('1');
-    //  Mock waiting for 10 second later for cookie to expire
-    const futureTime = new Date(Date.now() + 10000).valueOf();
-    global.Date.now = jest.fn(() => futureTime);
+
+    const sess = await sessionStore.get(sessionId as string);
+    // Force 10 sec back in the past for cookie to expire
+    sess!.cookie.expires! = new Date(sess!.cookie.expires!.valueOf() - 10000)
+    await sessionStore.set(sessionId as string, sess!)
+
     await agent.get('/').expect('0');
     //  Check in the store
     expect(await sessionStore.get(sessionId as string)).toBeNull();
@@ -426,7 +488,5 @@ describe('MemoryStore', () => {
       // @ts-ignore
       await sessionStore.touch(sessionId as string, sessionInstance)
     ).toBeUndefined();
-    // @ts-ignore
-    global.Date.now.mockReset();
   });
 });

--- a/test/integration/api-routes/next-env.d.ts
+++ b/test/integration/api-routes/next-env.d.ts
@@ -2,6 +2,6 @@
 /// <reference types="next/types/global" />
 declare module 'http' {
   export interface IncomingMessage {
-    session: Session;
+    session: import("../../../src/types").Session;
   }
 }

--- a/test/integration/get-initial-props/next-env.d.ts
+++ b/test/integration/get-initial-props/next-env.d.ts
@@ -2,6 +2,6 @@
 /// <reference types="next/types/global" />
 declare module 'http' {
   export interface IncomingMessage {
-    session: Session;
+    session: import("../../../src/types").Session;
   }
 }

--- a/test/integration/get-server-side-props/next-env.d.ts
+++ b/test/integration/get-server-side-props/next-env.d.ts
@@ -2,6 +2,6 @@
 /// <reference types="next/types/global" />
 declare module 'http' {
   export interface IncomingMessage {
-    session: Session;
+    session: import("../../../src/types").Session;
   }
 }


### PR DESCRIPTION
This PR removes `rolling` option and instead reset cookie `max-age` whenever the session is touched, which is the equivalent of setting it to `true`.

## Rationale

Setting `rolling` to `false` leads to mismatch between server and agent, especially if `touch` is enabled.

Since even if session is touched (has its lifetime extended) on the server, the cookie expiry in browser does not reflect that. Consequently, the browser expires the cookie earlier than expected.

This change makes it so that if the session is touched, the cookie should be updated in the browser (`set-cookie` header is set).

If you do not want too many `set-cookie` headers, it is possible to set `touchAfter` to a high value. This will also avoid forcing the session store to `touch` the session, helping db load.

## Breaking?

The default of `options.touchAfter` is set to `-1` (disabled) in this PR. If `options.touchAfter` is set to a value > 0, it works as expected, with the addition of the browser cookie expiry is also updated (set-cookie header set).

The reason is that if `options.rolling` is `false` (used to be default), `touchAfter` (even when defaults to `0` aka `always`) / touch functionality does not have any real effect, even when the session store does touch the session, because the cookie lifetime in the browser is not extended. Thus, it is better to default it to `-1` (disabled)

So, even with this change, it is unlikely for this to be a breaking change.

For compatibility, if `options.rolling` is `true`, `touchAfter` will be defaulted to `0` instead.

Also fix #318 (https://github.com/hoangvvo/next-session/blob/9defcbf5eb7e3a7f142b1ced9147f355285a9b3d/src/core.ts#L183)