### PR TITLE
Fix decode option type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,7 @@ export interface Options {
   store?: SessionStore | ExpressStore;
   genid?: () => string;
   encode?: (rawSid: string) => string;
-  decode?: (encryptedSid: string) => string;
+  decode?: (encryptedSid: string) => string | null;
   rolling?: boolean;
   touchAfter?: number;
   cookie?: CookieOptions;


### PR DESCRIPTION
Hello again.

README doc saying below.

```
encode: (sid) => (sid ? 's:' + signature.sign(sid, secret) : null),
```

This is mismatched with `types.ts` at the moment.

The real usage is here https://github.com/hoangvvo/next-session/blob/master/src/core.ts#L157-L159 .

```
  if (sessId && options.decode) sessId = options.decode(sessId);

  const sess = sessId ? await options.store.__get(sessId) : null;
```

~And I get this supports falsy values correctly, so I thought this is the `types.ts` problem.~

Sorry, little confused. Maybe around `decode`, this pr is applicable.

The side of `encode`, this may be documentation problem. To make matching with `types.ts`, it will be like...

```
encode: (sid) => 's:' + signature.sign(sid, secret),
```

I, however, am not sure this may not be served nullish values...
