### PR TITLE
Correct to set cookie.httpOnly option to false

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -91,7 +91,7 @@ export default function session(options: Options = {}) {
         [isNew]: true,
         cookie: {
           path: cookieOpts.path || "/",
-          httpOnly: cookieOpts.httpOnly || true,
+          httpOnly: cookieOpts.httpOnly ?? true,
           domain: cookieOpts.domain || undefined,
           sameSite: cookieOpts.sameSite,
           secure: cookieOpts.secure || false,

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -48,6 +48,14 @@ describe("session()", () => {
     );
     expect(store.get).not.toHaveBeenCalled();
   });
+  test("return httpOnly false cookie", async () => {
+    const cookie = {
+      httpOnly: false,
+    };
+    const sess = await session({ cookie })({}, {});
+
+    expect(sess.cookie.httpOnly).toBeFalsy();
+  });
   test("not set cookie header if session is not populated", async () => {
     const res = await inject(
       async (req, res) => {


### PR DESCRIPTION
Even if the httpOnly option is set to false, it is set to true.
The logical OR (||) operator (logical disjunction) for a set of operands is true if and only if one or more of its operands is true.
So changed to use Nullish coalescing operator(??).

Issue: https://github.com/hoangvvo/next-session/issues/353

See also
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR
  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator