### PR TITLE
Expose `req` to `genid` function similar to express-session

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ server.listen(8080);
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
 | name            | The name of the cookie to be read from the request and set to the response.                                                                  | `sid`                                    |
 | store           | The session store instance to be used. **Required** to work in production!                                                                   | `MemoryStore`                            |
-| genid           | The function that generates a string for a new session ID.                                                                                   | [`nanoid`](https://github.com/ai/nanoid) |
+| genid           | The function that exposes the `req` object as a parameter and generates a string for a new session ID.                                                                                   | [`(() => nanoid())`](https://github.com/ai/nanoid) |
 | encode          | Transforms session ID before setting cookie. It takes the raw session ID and returns the decoded/decrypted session ID.                       | undefined                                |
 | decode          | Transforms session ID back while getting from cookie. It should return the encoded/encrypted session ID                                      | undefined                                |
 | touchAfter      | Only touch after an amount of time **(in seconds)** since last access. Disabled by default or if set to `-1`. See [touchAfter](#touchAfter). | `-1` (Disabled)                          |

--- a/src/session.ts
+++ b/src/session.ts
@@ -11,7 +11,7 @@ export default function session<T extends SessionRecord = SessionRecord>(options
 
   const name = options.name || "sid";
   const store = options.store || new MemoryStore();
-  const genId = options.genid || nanoid;
+  const genId = options.genid || (() => nanoid());
   const encode = options.encode;
   const decode = options.decode;
   const touchAfter = options.touchAfter ?? -1;
@@ -88,7 +88,7 @@ export default function session<T extends SessionRecord = SessionRecord>(options
         }
       }
     } else {
-      sessionId = genId();
+      sessionId = genId(req);
       session = {
         [isNew]: true,
         cookie: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,7 +40,7 @@ export interface SessionStore {
 export interface Options {
   name?: string;
   store?: SessionStore;
-  genid?: () => string;
+  genid?: (req: IncomingMessage & { session?: Session }) => string;
   encode?: (rawSid: string) => string;
   decode?: (encryptedSid: string) => string | null;
   touchAfter?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { isDestroyed, isNew, isTouched } from "./symbol";
+import { IncomingMessage } from "http";
 
 export type SessionRecord = Record<string, any>
 


### PR DESCRIPTION
Pass the request object to the id generator function as done by express-session, to allow generating session ids based off of some data in the request.