### PR TITLE
BREAKING: Add function to retrieve session from next cookies

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { isDestroyed, isNew, isTouched } from "./symbol";
 
-export type SessionRecord = Record<string, any>
+export type SessionRecord = Record<string, any>;
 
 export type SessionData<T = SessionRecord> = {
   cookie: Cookie;
@@ -14,7 +14,7 @@ export type Session<T extends SessionRecord = SessionRecord> = {
   [isNew]?: boolean;
   [isTouched]?: boolean;
   [isDestroyed]?: boolean;
-} & SessionData<T>
+} & SessionData<T>;
 
 type Cookie = {
   httpOnly: boolean;
@@ -29,6 +29,10 @@ type Cookie = {
       expires: Date;
     }
 );
+
+export type NextCookies = {
+  get: (key: string) => { name: string; value: string } | undefined;
+};
 
 export interface SessionStore {
   get(sid: string): Promise<SessionData | null | undefined>;

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -438,7 +438,6 @@ describe("session()", () => {
       expect(mockCookies.get).toHaveBeenCalledWith(name);
       expect(store.get).toHaveBeenCalledWith(cook.value);
     });
-
     test("should call decode when fetching session", async () => {
       const store = {
         get: jest.fn(),
@@ -457,6 +456,24 @@ describe("session()", () => {
       expect(mockCookies.get).toHaveBeenCalledWith(name);
       expect(decode).toHaveBeenCalledWith(cook.value);
       expect(store.get).toHaveBeenCalledWith(decodedValue);
+    });
+    test("should return null if cookie is undefined", async () => {
+      const store = {
+        get: jest.fn(),
+      };
+      const name = "foo";
+
+      const mockCookies = {
+        get: jest.fn((key) => undefined),
+      } as NextCookies;
+
+      const result = await session({ store, name }).getSessionFromCookies(
+        mockCookies
+      );
+
+      expect(result).toBe(null);
+      expect(mockCookies.get).toHaveBeenCalledWith(name);
+      expect(store.get).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -5,7 +5,7 @@ import { inject } from "light-my-request";
 import MemoryStore from "../src/memory-store";
 import session from "../src/session";
 import { isNew, isTouched } from "../src/symbol";
-import { Session } from "../src/types";
+import { NextCookies, Session } from "../src/types";
 
 const defaultCookie = {
   domain: undefined,
@@ -16,403 +16,424 @@ const defaultCookie = {
 };
 
 describe("session()", () => {
-  test("return a function", () => {
-    expect(typeof session()).toBe("function");
+  test("return an object with 2 function properties", () => {
+    const theSession = session();
+    expect(typeof theSession).toBe("object");
+    expect(typeof theSession.getSession).toBe("function");
+    expect(typeof theSession.getSessionFromCookies).toBe("function");
   });
-  test("returns the session after resolve", async () => {
-    await inject(
-      async (req, res) => {
-        const sess = await session()(req, res);
-        expect(sess).toEqual({
-          cookie: defaultCookie,
-          [isNew]: true,
-        });
-        expect(req.session).toBe(sess);
-        res.end();
-      },
-      { path: "/" }
-    );
-  });
-  test("return if req.session is defined", async () => {
-    const store = {
-      get: jest.fn(),
-    };
-    await inject(
-      async (req, res) => {
-        req.session = {};
-        const sess = await session({ store })(req, res);
-        expect(sess).toBe(req.session);
-        res.end();
-      },
-      { path: "/", headers: { cookie: "sid=foo" } }
-    );
-    expect(store.get).not.toHaveBeenCalled();
-  });
-  test("return httpOnly false cookie", async () => {
-    const cookie = {
-      httpOnly: false,
-    };
-    const sess = await session({ cookie })({}, {});
+  describe("getSession()", () => {
+    test("returns the session after resolve", async () => {
+      await inject(
+        async (req, res) => {
+          const sess = await session().getSession(req, res);
+          expect(sess).toEqual({
+            cookie: defaultCookie,
+            [isNew]: true,
+          });
+          expect(req.session).toBe(sess);
+          res.end();
+        },
+        { path: "/" }
+      );
+    });
+    test("return if req.session is defined", async () => {
+      const store = {
+        get: jest.fn(),
+      };
+      await inject(
+        async (req, res) => {
+          req.session = {};
+          const sess = await session({ store }).getSession(req, res);
+          expect(sess).toBe(req.session);
+          res.end();
+        },
+        { path: "/", headers: { cookie: "sid=foo" } }
+      );
+      expect(store.get).not.toHaveBeenCalled();
+    });
+    test("return httpOnly false cookie", async () => {
+      const cookie = {
+        httpOnly: false,
+      };
+      const sess = await session({ cookie }).getSession({}, {});
 
-    expect(sess.cookie.httpOnly).toBeFalsy();
-  });
-  test("not set cookie header if session is not populated", async () => {
-    const res = await inject(
-      async (req, res) => {
-        await session()(req, res);
-        res.end();
-      },
-      { path: "/" }
-    );
-    expect(res.headers).not.toHaveProperty("set-cookie");
-  });
-  test("should set cookie header and save session", async () => {
-    const store = {
-      get: jest.fn(),
-      set: jest.fn(() => Promise.resolve()),
-    };
-    let id: string;
-    const res = await inject(
-      async (req, res) => {
-        await session({ store })(req, res);
-        req.session.foo = "bar";
-        id = req.session.id;
-        res.end();
-      },
-      { path: "/" }
-    );
-    expect(res.headers).toHaveProperty("set-cookie");
-    expect(res.headers["set-cookie"]).toBe(`sid=${id}; Path=/; HttpOnly`);
-    expect(store.set).toHaveBeenCalledWith(id, {
-      foo: "bar",
-      cookie: defaultCookie,
-      [isNew]: true,
+      expect(sess.cookie.httpOnly).toBeFalsy();
     });
-    await inject(
-      async (req, res) => {
-        await session({ store })(req, res);
-        req.session.foo = "bar";
-        res.end();
-      },
-      { path: "/", headers: { cookie: `sid=${id}` } }
-    );
-    expect(store.get).toHaveBeenCalledWith(id);
-  });
-  test("should set cookie header and save session (autoCommit = false)", async () => {
-    const store = {
-      get: jest.fn(),
-      set: jest.fn(() => Promise.resolve()),
-    };
-    let id: string;
-    const res = await inject(
-      async (req, res) => {
-        await session({ store, autoCommit: false })(req, res);
-        req.session.foo = "bar";
-        id = req.session.id;
-        await req.session.commit();
-        res.end();
-      },
-      { path: "/" }
-    );
-    expect(res.headers).toHaveProperty("set-cookie");
-    expect(res.headers["set-cookie"]).toBe(`sid=${id}; Path=/; HttpOnly`);
-    expect(store.set).toHaveBeenCalledWith(id, {
-      foo: "bar",
-      cookie: defaultCookie,
-      [isNew]: true,
+    test("not set cookie header if session is not populated", async () => {
+      const res = await inject(
+        async (req, res) => {
+          await session().getSession(req, res);
+          res.end();
+        },
+        { path: "/" }
+      );
+      expect(res.headers).not.toHaveProperty("set-cookie");
     });
-    await inject(
-      async (req, res) => {
-        await session({ store })(req, res);
-        req.session.foo = "bar";
-        res.end();
-      },
-      { path: "/", headers: { cookie: `sid=${id}` } }
-    );
-    expect(store.get).toHaveBeenCalledWith(id);
-  });
-  test("set session expiry if maxAge is set", async () => {
-    const store = {
-      get: jest.fn(),
-      set: jest.fn(() => Promise.resolve()),
-    };
-    let id: string;
-    let expires: Date;
-    const res = await inject(
-      async (req, res) => {
-        await session({ store, cookie: { maxAge: 10 } })(req, res);
-        req.session.foo = "bar";
-        id = req.session.id;
-        expect(req.session.cookie.expires).toBeInstanceOf(Date);
-        expires = req.session.cookie.expires;
-        res.end();
-      },
-      { path: "/" }
-    );
-    expect(res.headers).toHaveProperty("set-cookie");
-    expect(res.headers["set-cookie"]).toBe(
-      `sid=${id}; Path=/; Expires=${expires.toUTCString()}; HttpOnly`
-    );
-    expect(store.set).toHaveBeenCalledWith(id, {
-      foo: "bar",
-      cookie: { ...defaultCookie, expires, maxAge: 10 },
-      [isNew]: true,
+    test("should set cookie header and save session", async () => {
+      const store = {
+        get: jest.fn(),
+        set: jest.fn(() => Promise.resolve()),
+      };
+      let id: string;
+      const res = await inject(
+        async (req, res) => {
+          await session({ store }).getSession(req, res);
+          req.session.foo = "bar";
+          id = req.session.id;
+          res.end();
+        },
+        { path: "/" }
+      );
+      expect(res.headers).toHaveProperty("set-cookie");
+      expect(res.headers["set-cookie"]).toBe(`sid=${id}; Path=/; HttpOnly`);
+      expect(store.set).toHaveBeenCalledWith(id, {
+        foo: "bar",
+        cookie: defaultCookie,
+        [isNew]: true,
+      });
+      await inject(
+        async (req, res) => {
+          await session({ store }).getSession(req, res);
+          req.session.foo = "bar";
+          res.end();
+        },
+        { path: "/", headers: { cookie: `sid=${id}` } }
+      );
+      expect(store.get).toHaveBeenCalledWith(id);
     });
-    await inject(
-      async (req, res) => {
-        await session({ store })(req, res);
-        req.session.foo = "bar";
-        res.end();
-      },
-      { path: "/", headers: { cookie: `sid=${id}` } }
-    );
-    expect(store.get).toHaveBeenCalledWith(id);
-  });
-  test("should destroy session and unset cookie", async () => {
-    const store = new MemoryStore();
-    store.destroy = jest.fn();
-    store.set = jest.fn();
-    store.touch = jest.fn();
-    const sid = "foo";
-    await store.store.set(
-      sid,
-      JSON.stringify({ foo: "bar", cookie: defaultCookie })
-    );
-    const res = await inject(
-      async (req, res) => {
-        await session({ store })(req, res);
-        req.session.foo = "quz";
-        await req.session.destroy();
-        res.end();
-      },
-      { path: "/", headers: { cookie: `sid=${sid}` } }
-    );
-    expect(store.destroy).toHaveBeenCalledWith(sid);
-    expect(store.set).not.toHaveBeenCalled();
-    expect(store.touch).not.toHaveBeenCalled();
-    expect(res.headers["set-cookie"]).toBe(
-      `sid=${sid}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly`
-    );
-  });
-  test("should destroy session and unset cookie (autoCommit=false)", async () => {
-    const store = new MemoryStore();
-    store.destroy = jest.fn();
-    store.set = jest.fn();
-    store.touch = jest.fn();
-    const sid = "foo";
-    await store.store.set(
-      sid,
-      JSON.stringify({ foo: "bar", cookie: defaultCookie })
-    );
-    const res = await inject(
-      async (req, res) => {
-        await session({ store, autoCommit: false })(req, res);
-        req.session.foo = "quz";
-        await req.session.destroy();
-        expect(req).not.toHaveProperty("session");
-        res.end();
-      },
-      { path: "/", headers: { cookie: `sid=${sid}` } }
-    );
-    expect(store.destroy).toHaveBeenCalledWith(sid);
-    expect(store.set).not.toHaveBeenCalled();
-    expect(store.touch).not.toHaveBeenCalled();
-    expect(res.headers["set-cookie"]).toBe(
-      `sid=${sid}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly`
-    );
-  });
-  test("not to modify res.writeHead and res.end if autoCommit = false", async () => {
-    const req = { headers: {} } as any;
-    const noop = () => undefined;
-    const res = { writeHead: noop, end: noop };
-    await session({ autoCommit: false })(req, res);
-    expect(res.end).toBe(noop);
-    expect(res.writeHead).toBe(noop);
-  });
-  test("not make res.writeHead and res.end async", async () => {
-    const req = { headers: {} } as any;
-    const res = {
-      writeHead() {
-        return this;
-      },
-      end: () => undefined,
-    };
-    await session({ autoCommit: true })(req, res);
-    expect(typeof res.end()).not.toEqual("object");
-    expect(res.writeHead()).toBe(res);
-  });
-  test("not touch (touchAfter = -1) by default", async () => {
-    const store = new MemoryStore();
-    store.touch = jest.fn();
-    const expires = new Date(Date.now() + 1000);
-    await store.set("foo", {
-      cookie: { ...defaultCookie, expires, maxAge: 5 },
+    test("should set cookie header and save session (autoCommit = false)", async () => {
+      const store = {
+        get: jest.fn(),
+        set: jest.fn(() => Promise.resolve()),
+      };
+      let id: string;
+      const res = await inject(
+        async (req, res) => {
+          await session({ store, autoCommit: false }).getSession(req, res);
+          req.session.foo = "bar";
+          id = req.session.id;
+          await req.session.commit();
+          res.end();
+        },
+        { path: "/" }
+      );
+      expect(res.headers).toHaveProperty("set-cookie");
+      expect(res.headers["set-cookie"]).toBe(`sid=${id}; Path=/; HttpOnly`);
+      expect(store.set).toHaveBeenCalledWith(id, {
+        foo: "bar",
+        cookie: defaultCookie,
+        [isNew]: true,
+      });
+      await inject(
+        async (req, res) => {
+          await session({ store }).getSession(req, res);
+          req.session.foo = "bar";
+          res.end();
+        },
+        { path: "/", headers: { cookie: `sid=${id}` } }
+      );
+      expect(store.get).toHaveBeenCalledWith(id);
     });
-    const res = await inject(
-      async (req, res) => {
-        await session({ store })(req, res);
-        expect(req.session[isTouched]).toBeFalsy();
-        res.end(String(req.session.cookie.expires.getTime()));
-      },
-      { path: "/", headers: { cookie: "sid=foo" } }
-    );
-    expect(store.touch).not.toHaveBeenCalled();
-    expect(Number(res.payload)).toEqual(expires.getTime());
-  });
-  test("touch if session life time > touchAfter", async () => {
-    const store = new MemoryStore();
-    store.touch = jest.fn(() => Promise.resolve());
-    const expires = new Date(Date.now() + 2000);
-    await store.set("foo", {
-      cookie: { ...defaultCookie, expires, maxAge: 5 },
+    test("set session expiry if maxAge is set", async () => {
+      const store = {
+        get: jest.fn(),
+        set: jest.fn(() => Promise.resolve()),
+      };
+      let id: string;
+      let expires: Date;
+      const res = await inject(
+        async (req, res) => {
+          await session({ store, cookie: { maxAge: 10 } }).getSession(req, res);
+          req.session.foo = "bar";
+          id = req.session.id;
+          expect(req.session.cookie.expires).toBeInstanceOf(Date);
+          expires = req.session.cookie.expires;
+          res.end();
+        },
+        { path: "/" }
+      );
+      expect(res.headers).toHaveProperty("set-cookie");
+      expect(res.headers["set-cookie"]).toBe(
+        `sid=${id}; Path=/; Expires=${expires.toUTCString()}; HttpOnly`
+      );
+      expect(store.set).toHaveBeenCalledWith(id, {
+        foo: "bar",
+        cookie: { ...defaultCookie, expires, maxAge: 10 },
+        [isNew]: true,
+      });
+      await inject(
+        async (req, res) => {
+          await session({ store }).getSession(req, res);
+          req.session.foo = "bar";
+          res.end();
+        },
+        { path: "/", headers: { cookie: `sid=${id}` } }
+      );
+      expect(store.get).toHaveBeenCalledWith(id);
     });
-    let newExpires: Date;
-    const res = await inject(
-      async (req, res) => {
-        await session({ store, touchAfter: 1 })(req, res);
-        expect(req.session[isTouched]).toBe(true);
-        newExpires = req.session.cookie.expires;
-        res.end();
-      },
-      { path: "/", headers: { cookie: "sid=foo" } }
-    );
-    expect(newExpires.getTime()).toBeGreaterThan(expires.getTime());
-    expect(res.headers["set-cookie"]).toEqual(
-      `sid=foo; Path=/; Expires=${newExpires.toUTCString()}; HttpOnly`
-    );
-    expect(store.touch).toHaveBeenCalledWith("foo", {
-      cookie: { ...defaultCookie, expires: newExpires, maxAge: 5 },
-      [isTouched]: true,
+    test("should destroy session and unset cookie", async () => {
+      const store = new MemoryStore();
+      store.destroy = jest.fn();
+      store.set = jest.fn();
+      store.touch = jest.fn();
+      const sid = "foo";
+      store.store.set(
+        sid,
+        JSON.stringify({ foo: "bar", cookie: defaultCookie })
+      );
+      const res = await inject(
+        async (req, res) => {
+          await session({ store }).getSession(req, res);
+          req.session.foo = "quz";
+          await req.session.destroy();
+          res.end();
+        },
+        { path: "/", headers: { cookie: `sid=${sid}` } }
+      );
+      expect(store.destroy).toHaveBeenCalledWith(sid);
+      expect(store.set).not.toHaveBeenCalled();
+      expect(store.touch).not.toHaveBeenCalled();
+      expect(res.headers["set-cookie"]).toBe(
+        `sid=${sid}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly`
+      );
     });
-  });
-  test("not touch session life time < touchAfter", async () => {
-    const store = new MemoryStore();
-    store.touch = jest.fn(() => Promise.resolve());
-    const expires = new Date(Date.now() + 2000);
-    await store.set("foo", {
-      cookie: { ...defaultCookie, expires, maxAge: 5 },
+    test("should destroy session and unset cookie (autoCommit=false)", async () => {
+      const store = new MemoryStore();
+      store.destroy = jest.fn();
+      store.set = jest.fn();
+      store.touch = jest.fn();
+      const sid = "foo";
+      store.store.set(
+        sid,
+        JSON.stringify({ foo: "bar", cookie: defaultCookie })
+      );
+      const res = await inject(
+        async (req, res) => {
+          await session({ store, autoCommit: false }).getSession(req, res);
+          req.session.foo = "quz";
+          await req.session.destroy();
+          expect(req).not.toHaveProperty("session");
+          res.end();
+        },
+        { path: "/", headers: { cookie: `sid=${sid}` } }
+      );
+      expect(store.destroy).toHaveBeenCalledWith(sid);
+      expect(store.set).not.toHaveBeenCalled();
+      expect(store.touch).not.toHaveBeenCalled();
+      expect(res.headers["set-cookie"]).toBe(
+        `sid=${sid}; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly`
+      );
     });
-    let newExpires: Date;
-    const res = await inject(
-      async (req, res) => {
-        await session({ store, touchAfter: 10 })(req, res);
-        expect(req.session[isTouched]).toBeFalsy();
-        newExpires = req.session.cookie.expires;
-        res.end();
-      },
-      { path: "/", headers: { cookie: "sid=foo" } }
-    );
-    expect(newExpires.getTime()).toEqual(expires.getTime());
-    expect(res.headers).not.toHaveProperty("set-cookie");
-    expect(store.touch).not.toHaveBeenCalled();
-  });
-  test("support calling res.end() multiple times", (done) => {
-    // This must be tested with a real server to verify headers sent error
-    // https://github.com/hoangvvo/next-session/pull/31
-    const server = createServer(async (req, res) => {
-      await session()(req, res);
-      req.session.foo = "bar";
-      res.end("Hello, world!");
-      res.end();
+    test("not to modify res.writeHead and res.end if autoCommit = false", async () => {
+      const req = { headers: {} } as any;
+      const noop = () => undefined;
+      const res = { writeHead: noop, end: noop };
+      await session({ autoCommit: false }).getSession(req, res);
+      expect(res.end).toBe(noop);
+      expect(res.writeHead).toBe(noop);
     });
-    server.listen(
-      async (req, res) => {
-        await session()(req, res);
+    test("not make res.writeHead and res.end async", async () => {
+      const req = { headers: {} } as any;
+      const res = {
+        writeHead() {
+          return this;
+        },
+        end: () => undefined,
+      };
+      await session({ autoCommit: true }).getSession(req, res);
+      expect(typeof res.end()).not.toEqual("object");
+      expect(res.writeHead()).toBe(res);
+    });
+    test("not touch (touchAfter = -1) by default", async () => {
+      const store = new MemoryStore();
+      store.touch = jest.fn();
+      const expires = new Date(Date.now() + 1000);
+      await store.set("foo", {
+        cookie: { ...defaultCookie, expires, maxAge: 5 },
+      });
+      const res = await inject(
+        async (req, res) => {
+          await session({ store }).getSession(req, res);
+          expect(req.session[isTouched]).toBeFalsy();
+          res.end(String(req.session.cookie.expires.getTime()));
+        },
+        { path: "/", headers: { cookie: "sid=foo" } }
+      );
+      expect(store.touch).not.toHaveBeenCalled();
+      expect(Number(res.payload)).toEqual(expires.getTime());
+    });
+    test("touch if session life time > touchAfter", async () => {
+      const store = new MemoryStore();
+      store.touch = jest.fn(() => Promise.resolve());
+      const expires = new Date(Date.now() + 2000);
+      await store.set("foo", {
+        cookie: { ...defaultCookie, expires, maxAge: 5 },
+      });
+      let newExpires: Date;
+      const res = await inject(
+        async (req, res) => {
+          await session({ store, touchAfter: 1 }).getSession(req, res);
+          expect(req.session[isTouched]).toBe(true);
+          newExpires = req.session.cookie.expires;
+          res.end();
+        },
+        { path: "/", headers: { cookie: "sid=foo" } }
+      );
+      expect(newExpires.getTime()).toBeGreaterThan(expires.getTime());
+      expect(res.headers["set-cookie"]).toEqual(
+        `sid=foo; Path=/; Expires=${newExpires.toUTCString()}; HttpOnly`
+      );
+      expect(store.touch).toHaveBeenCalledWith("foo", {
+        cookie: { ...defaultCookie, expires: newExpires, maxAge: 5 },
+        [isTouched]: true,
+      });
+    });
+    test("not touch session life time < touchAfter", async () => {
+      const store = new MemoryStore();
+      store.touch = jest.fn(() => Promise.resolve());
+      const expires = new Date(Date.now() + 2000);
+      await store.set("foo", {
+        cookie: { ...defaultCookie, expires, maxAge: 5 },
+      });
+      let newExpires: Date;
+      const res = await inject(
+        async (req, res) => {
+          await session({ store, touchAfter: 10 }).getSession(req, res);
+          expect(req.session[isTouched]).toBeFalsy();
+          newExpires = req.session.cookie.expires;
+          res.end();
+        },
+        { path: "/", headers: { cookie: "sid=foo" } }
+      );
+      expect(newExpires.getTime()).toEqual(expires.getTime());
+      expect(res.headers).not.toHaveProperty("set-cookie");
+      expect(store.touch).not.toHaveBeenCalled();
+    });
+    test("support calling res.end() multiple times", (done) => {
+      // This must be tested with a real server to verify headers sent error
+      // https://github.com/hoangvvo/next-session/pull/31
+      const server = createServer(async (req, res) => {
+        await session().getSession(req, res);
         req.session.foo = "bar";
         res.end("Hello, world!");
         res.end();
-      },
-      function callback() {
-        const address = this.address();
-        request(`http://127.0.0.1:${address.port}/`, (res) => {
-          let data = "";
-          res.on("data", (d) => {
-            if (d) data += d;
-          });
-          res.on("end", () => {
-            expect(data).toEqual("Hello, world!");
-            server.close(done);
-          });
-          res.on("error", done);
-        })
-          .on("error", done)
-          .end();
-      }
-    );
-  });
-  test("allow encode and decode sid", async () => {
-    const decode = (key: string) => {
-      if (key.startsWith("sig.")) return key.substring(4);
-      return null;
-    };
-    const encode = (key: string) => {
-      return `sig.${key}`;
-    };
-    const store = new MemoryStore();
-    const sessionFn = session({ store, encode, decode });
-    let sid: string;
-    const res = await inject(
-      async (req, res) => {
-        await sessionFn(req, res);
-        req.session.foo = "bar";
-        sid = req.session.id;
-        res.end();
-      },
-      { path: "/" }
-    );
-    expect(res.headers["set-cookie"]).toBe(
-      `sid=${encode(sid)}; Path=/; HttpOnly`
-    );
-    expect(store.store.has(sid)).toBe(true);
-    const handler = async (
-      req: IncomingMessage & { session: Session },
-      res: ServerResponse
-    ) => {
-      await sessionFn(req, res);
-      res.end(req.session.foo);
-    };
-    const res2 = await inject(handler, {
-      path: "/",
-      headers: { cookie: `sid=${encode(sid)}` },
-    });
-    expect(res2.payload).toEqual("bar");
-    const res3 = await inject(handler, {
-      path: "/",
-      headers: { cookie: `sid=${sid}` },
-    });
-    expect(res3.payload).toEqual("");
-  });
-  test("set cookie correctly after res.writeHead in autoCommit", async () => {
-    const res = await inject(
-      async (req, res) => {
-        await session()(req, res);
-        req.session.foo = "bar";
-        res.writeHead(302, { Location: "/login" }).end();
-      },
-      { path: "/" }
-    );
-    expect(res.headers).toHaveProperty("set-cookie");
-  });
-  test("should convert to date if store returns session.cookies.expires as string", async () => {
-    const store = {
-      get: async (id: string) => {
-        //  force sess.cookie.expires to be string
-        return JSON.parse(
-          JSON.stringify({
-            cookie: { maxAge: 100000, expires: new Date(Date.now() + 4000) },
+      });
+      server.listen(
+        async (req, res) => {
+          await session().getSession(req, res);
+          req.session.foo = "bar";
+          res.end("Hello, world!");
+          res.end();
+        },
+        function callback() {
+          const address = this.address();
+          request(`http://127.0.0.1:${address.port}/`, (res) => {
+            let data = "";
+            res.on("data", (d) => {
+              if (d) data += d;
+            });
+            res.on("end", () => {
+              expect(data).toEqual("Hello, world!");
+              server.close(done);
+            });
+            res.on("error", done);
           })
-        );
-      },
-      set: async (sid: string, sess: SessionData) => undefined,
-      destroy: async (id: string) => undefined,
-    };
-    await inject(
-      async (req, res) => {
-        await session({ store })(req, res);
-        expect(req.session.cookie.expires).toBeInstanceOf(Date);
-        res.end();
-      },
-      { path: "/", headers: { cookie: "sid=foo" } }
-    );
+            .on("error", done)
+            .end();
+        }
+      );
+    });
+    test("allow encode and decode sid", async () => {
+      const decode = (key: string) => {
+        if (key.startsWith("sig.")) return key.substring(4);
+        return null;
+      };
+      const encode = (key: string) => {
+        return `sig.${key}`;
+      };
+      const store = new MemoryStore();
+      const sessionFn = session({ store, encode, decode }).getSession;
+      let sid: string;
+      const res = await inject(
+        async (req, res) => {
+          await sessionFn(req, res);
+          req.session.foo = "bar";
+          sid = req.session.id;
+          res.end();
+        },
+        { path: "/" }
+      );
+      expect(res.headers["set-cookie"]).toBe(
+        `sid=${encode(sid)}; Path=/; HttpOnly`
+      );
+      expect(store.store.has(sid)).toBe(true);
+      const handler = async (
+        req: IncomingMessage & { session: Session },
+        res: ServerResponse
+      ) => {
+        await sessionFn(req, res);
+        res.end(req.session.foo);
+      };
+      const res2 = await inject(handler, {
+        path: "/",
+        headers: { cookie: `sid=${encode(sid)}` },
+      });
+      expect(res2.payload).toEqual("bar");
+      const res3 = await inject(handler, {
+        path: "/",
+        headers: { cookie: `sid=${sid}` },
+      });
+      expect(res3.payload).toEqual("");
+    });
+    test("set cookie correctly after res.writeHead in autoCommit", async () => {
+      const res = await inject(
+        async (req, res) => {
+          await session().getSession(req, res);
+          req.session.foo = "bar";
+          res.writeHead(302, { Location: "/login" }).end();
+        },
+        { path: "/" }
+      );
+      expect(res.headers).toHaveProperty("set-cookie");
+    });
+    test("should convert to date if store returns session.cookies.expires as string", async () => {
+      const store = {
+        get: async (id: string) => {
+          //  force sess.cookie.expires to be string
+          return JSON.parse(
+            JSON.stringify({
+              cookie: { maxAge: 100000, expires: new Date(Date.now() + 4000) },
+            })
+          );
+        },
+        set: async (sid: string, sess: SessionData) => undefined,
+        destroy: async (id: string) => undefined,
+      };
+      await inject(
+        async (req, res) => {
+          await session({ store }).getSession(req, res);
+          expect(req.session.cookie.expires).toBeInstanceOf(Date);
+          res.end();
+        },
+        { path: "/", headers: { cookie: "sid=foo" } }
+      );
+    });
+  });
+  describe("getSessionFromCookies()", () => {
+    test("returns session from store if cookies has session", async () => {
+      const store = {
+        get: jest.fn(),
+      };
+      const name = "foo";
+      const cook = { name, value: "bar" };
+      const mockCookies = {
+        get: jest.fn((key) => cook),
+      } as NextCookies;
+      await session({ store, name }).getSessionFromCookies(mockCookies);
+
+      expect(mockCookies.get).toHaveBeenCalledWith(name);
+      expect(store.get).toHaveBeenCalledWith(cook.value);
+    });
   });
 });

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -425,15 +425,38 @@ describe("session()", () => {
       const store = {
         get: jest.fn(),
       };
+
       const name = "foo";
       const cook = { name, value: "bar" };
+
       const mockCookies = {
         get: jest.fn((key) => cook),
       } as NextCookies;
+
       await session({ store, name }).getSessionFromCookies(mockCookies);
 
       expect(mockCookies.get).toHaveBeenCalledWith(name);
       expect(store.get).toHaveBeenCalledWith(cook.value);
+    });
+
+    test("should call decode when fetching session", async () => {
+      const store = {
+        get: jest.fn(),
+      };
+      const name = "foo";
+      const decodedValue = "rab";
+      const decode = jest.fn(() => decodedValue);
+
+      const cook = { name, value: "bar" };
+      const mockCookies = {
+        get: jest.fn((key) => cook),
+      } as NextCookies;
+
+      await session({ store, name, decode }).getSessionFromCookies(mockCookies);
+
+      expect(mockCookies.get).toHaveBeenCalledWith(name);
+      expect(decode).toHaveBeenCalledWith(cook.value);
+      expect(store.get).toHaveBeenCalledWith(decodedValue);
     });
   });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -8,7 +8,7 @@ describe("hash()", () => {
     const res = {} as any;
     await session({
       autoCommit: false,
-    })(req, res);
+    }).getSession(req, res);
     req.session.foo = "bar";
     expect(hash(req.session)).toEqual(`{"foo":"bar"}`);
   });


### PR DESCRIPTION
With Next 13, you can no longer rely on req and res being available if you're making a server component in the experimental app directory. To support this, I changed the `session` function to return an object with 2 functions instead of just a function. `getSession` is the function that it originally returned which accepts the request and response objects. The other, `getSessionFromCookies`, is made with Next 13's [cookies](https://beta.nextjs.org/docs/api-reference/cookies) function in mind. I expect the next `getSessionFromCookies` function to be used in a similar way in server components:

```typescript
import { getSessionFromCookies } from "./lib/session";
import { cookies } from "next/headers";

const ServerComponent = () => {
    const session = getSessionFromCookies(cookies());
    // do stuff with session
   return <div></div>;
};
```

It should be noted that the session retrieved this way will be "readonly" in the sense that changes to it cannot be committed to the store.