### PR TITLE
feature: Add session.regenerate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,17 @@ await session.commit();
 // always calling res.end or res.writeHead after the above
 ```
 
+### session.regenerate()
+
+Replace the current session ID with a new generated one. Return Promise.
+
+You **must** call `session.commit` if `autoCommit` is set to `false`.
+
+```javascript
+await session.regenerate();
+await session.commit(); // if `autoCommit` is set to `false`.
+```
+
 ### session.id
 
 The unique id that associates to the current session.

--- a/src/session.ts
+++ b/src/session.ts
@@ -25,6 +25,8 @@ export default function session<T extends SessionRecord = SessionRecord>(options
     id: string,
     _now: number
   ) {
+    let privateId = id;
+
     Object.defineProperties(session, {
       commit: {
         value: async function commit(this: TypedSession) {
@@ -38,6 +40,13 @@ export default function session<T extends SessionRecord = SessionRecord>(options
           this[isTouched] = true;
         },
       },
+      regenerate: {
+        value: async function regenerate(this: TypedSession) {
+          await store.destroy(this.id);
+          privateId = genId();
+          this[isTouched] = true;
+        },
+      },
       destroy: {
         value: async function destroy(this: TypedSession) {
           this[isDestroyed] = true;
@@ -47,7 +56,7 @@ export default function session<T extends SessionRecord = SessionRecord>(options
           delete req.session;
         },
       },
-      id: { value: id },
+      id: { get: () => privateId },
     });
   }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,7 +2,7 @@ import c from "cookie";
 import { IncomingMessage, ServerResponse } from "http";
 import { nanoid } from "nanoid";
 import MemoryStore from "./memory-store";
-import { isDestroyed, isNew, isTouched } from "./symbol";
+import { isDestroyed, isNew, isRegenerated, isTouched } from "./symbol";
 import { Options, Session, SessionRecord } from "./types";
 import { commitHeader, hash } from "./utils";
 
@@ -44,7 +44,7 @@ export default function session<T extends SessionRecord = SessionRecord>(options
         value: async function regenerate(this: TypedSession) {
           await store.destroy(this.id);
           privateId = genId();
-          this[isTouched] = true;
+          this[isRegenerated] = true;
         },
       },
       destroy: {
@@ -139,6 +139,7 @@ export default function session<T extends SessionRecord = SessionRecord>(options
         if (
           (session[isNew] && Object.keys(session).length > 1) ||
           session[isTouched] ||
+          session[isRegenerated] ||
           session[isDestroyed]
         ) {
           commitHeader(res, name, session, encode);

--- a/src/symbol.ts
+++ b/src/symbol.ts
@@ -1,3 +1,4 @@
 export const isTouched = Symbol("session.isTouched");
 export const isDestroyed = Symbol("session.isDestroyed");
 export const isNew = Symbol("session.isNew");
+export const isRegenerated = Symbol("session.isRegenerated");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { isDestroyed, isNew, isTouched } from "./symbol";
+import type { isDestroyed, isNew, isRegenerated, isTouched } from "./symbol";
 
 export type SessionRecord = Record<string, any>
 
@@ -10,9 +10,11 @@ export type Session<T extends SessionRecord = SessionRecord> = {
   id: string;
   touch(): void;
   commit(): Promise<void>;
+  regenerate(): Promise<void>;
   destroy(): Promise<void>;
   [isNew]?: boolean;
   [isTouched]?: boolean;
+  [isRegenerated]?: boolean;
   [isDestroyed]?: boolean;
 } & SessionData<T>
 

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -4,7 +4,7 @@ import { createServer, IncomingMessage, request, ServerResponse } from "http";
 import { inject } from "light-my-request";
 import MemoryStore from "../src/memory-store";
 import session from "../src/session";
-import { isNew, isTouched } from "../src/symbol";
+import { isNew, isRegenerated, isTouched } from "../src/symbol";
 import { Session } from "../src/types";
 
 const defaultCookie = {
@@ -191,7 +191,7 @@ describe("session()", () => {
     expect(store.set).toHaveBeenCalledWith(newSid, {
       foo: "quz",
       cookie: defaultCookie,
-      [isTouched]: true,
+      [isRegenerated]: true,
     });
     expect(res.headers["set-cookie"]).toBe(`sid=${newSid}; Path=/; HttpOnly`);
   });
@@ -222,7 +222,7 @@ describe("session()", () => {
     expect(store.set).toHaveBeenCalledWith(newSid, {
       foo: "quz",
       cookie: defaultCookie,
-      [isTouched]: true,
+      [isRegenerated]: true,
     });
     expect(res.headers["set-cookie"]).toBe(`sid=${newSid}; Path=/; HttpOnly`);
   });


### PR DESCRIPTION
[To prevent session fixation attacks,](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#renew-the-session-id-after-any-privilege-level-change) it would be useful to have an API to regenerate session ID.

`session.regenerate()` API replaces the current session ID with a new generated one. Return Promise.

```javascript
await session.regenerate();
await session.commit(); // if `autoCommit` is set to `false`.
```

This is similar to [express-session's Session.regenerate(callback)](https://www.npmjs.com/package/express-session#sessionregeneratecallback) and [PHP's session_regenerate_id](https://www.php.net/manual/en/function.session-regenerate-id.php).
