### PR TITLE
feat: support `maxAgeInMs`  and fully compatible with express-session on cookie.maxAge

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ server.listen(8080);
 | cookie.domain   | Specifies the value for the **Domain** `Set-Cookie` attribute.                                                                               | unset                                    |
 | cookie.sameSite | Specifies the value for the **SameSite** `Set-Cookie` attribute.                                                                             | unset                                    |
 | cookie.maxAge   | **(in seconds)** Specifies the value for the **Max-Age** `Set-Cookie` attribute.                                                             | unset (Browser session)                  |
+| cookie.maxInAge | **(in mill seconds)** Specifies the value for the **Max-Age** `Set-Cookie` attribute. (for comatible express-session storage adapter)        | unset (Browser session)                  |
 
 ### touchAfter
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -34,7 +34,7 @@ export default function session<T extends SessionRecord = SessionRecord>(options
       },
       touch: {
         value: async function commit(this: TypedSession) {
-          this.cookie.expires = new Date(_now + this.cookie.maxAge! * 1000);
+          this.cookie.expires = new Date(_now + this.cookie.maxAge!);
           this[isTouched] = true;
         },
       },
@@ -82,8 +82,8 @@ export default function session<T extends SessionRecord = SessionRecord>(options
       // Extends the expiry of the session if options.touchAfter is sastified
       if (touchAfter >= 0 && session.cookie.expires) {
         const lastTouchedTime =
-          session.cookie.expires.getTime() - session.cookie.maxAge * 1000;
-        if (_now - lastTouchedTime >= touchAfter * 1000) {
+          session.cookie.expires.getTime() - session.cookie.maxAge;
+        if (_now - lastTouchedTime >= touchAfter) {
           session.touch();
         }
       }
@@ -100,8 +100,12 @@ export default function session<T extends SessionRecord = SessionRecord>(options
         },
       } as TypedSession;
       if (cookieOpts.maxAge) {
-        session.cookie.maxAge = cookieOpts.maxAge;
+        session.cookie.maxAge = cookieOpts.maxAge * 1000;
         session.cookie.expires = new Date(_now + cookieOpts.maxAge * 1000);
+      }
+      if (cookieOpts.maxAgeInMs) {
+        session.cookie.maxAge = cookieOpts.maxAgeInMs;
+        session.cookie.expires = new Date(_now + cookieOpts.maxAgeInMs);
       }
 
       // Add session methods

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,10 @@ type Cookie = {
   secure: boolean;
   sameSite?: boolean | "lax" | "strict" | "none";
 } & (
-  | { maxAge?: undefined; expires?: undefined }
+  | {
+      maxAge?: undefined;
+      expires?: undefined;
+    }
   | {
       maxAge: number;
       expires: Date;
@@ -48,7 +51,9 @@ export interface Options {
     Pick<
       Cookie,
       "maxAge" | "httpOnly" | "path" | "domain" | "secure" | "sameSite"
-    >
+    > & {
+      maxAgeInMs: number
+    }
   >;
   autoCommit?: boolean;
 }


### PR DESCRIPTION
refs:  #369

## About
- Add `maxAgeInMs` option, refs: #369
- Keeps the internal `session.cookie.maxAge` in milliseconds so that expire is handled correctly by the express-session store adapter.
- `maxAge` can be used as before. However, when passing it to the store, `maxAge` is converted to milliseconds.

## Context
`connect-dynamodb` computes expires by inheriting `cookie.maxAge`.  [source](https://github.com/ca98am79/connect-dynamodb/blob/61f4618512951b43219169eeeba4582f4d0995e0/lib/connect-dynamodb.js#L347-L350)
And express-session expects `cookie.maxAge` to be milliseconds.
`next-session` is specified in seconds, which causes problems when `connect-dynamodb` and `next-session` are used in combination.
This is because `next-session` is not fully compatible with `express-session`.
refs: https://github.com/ca98am79/connect-dynamodb/pull/87#issuecomment-2121599981
